### PR TITLE
feat: GET campers endpoint

### DIFF
--- a/backend/typescript/models/camp.model.ts
+++ b/backend/typescript/models/camp.model.ts
@@ -1,9 +1,10 @@
 import { Schema, model } from "mongoose";
 import { AbstractCamp } from "./abstractCamp.model";
+import { Camper } from "./camper.model";
 
 export interface Camp extends AbstractCamp {
   baseCamp: Schema.Types.ObjectId;
-  campers: Schema.Types.ObjectId[];
+  campers: (Camper | Schema.Types.ObjectId)[];
   waitlist: Schema.Types.ObjectId[];
   startDate: Date;
   endDate: Date;

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -91,6 +91,82 @@ class CamperService implements ICamperService {
       chargeId: newCamper.chargeId,
     };
   }
+
+  async getAllCampers(): Promise<Array<CamperDTO>> {
+    let camperDtos: Array<CamperDTO> = [];
+
+    try {
+      const campers: Array<Camper> = await MgCamper.find();
+      camperDtos = campers.map((camper) => {
+        return {
+          id: camper.id,
+          firstName: camper.firstName,
+          lastName: camper.lastName,
+          age: camper.age,
+          contactName: camper.contactName,
+          contactEmail: camper.contactEmail,
+          contactNumber: camper.contactNumber,
+          camp: camper.camp ? camper.camp.toString() : "",
+          hasCamera: camper.hasCamera,
+          hasLaptop: camper.hasLaptop,
+          allergies: camper.allergies,
+          additionalDetails: camper.additionalDetails,
+          dropOffType: camper.dropOffType,
+          registrationDate: camper.registrationDate,
+          hasPaid: camper.hasPaid,
+          chargeId: camper.chargeId,
+        };
+      });
+    } catch (error: unknown) {
+      Logger.error(`Failed to get campers. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    return camperDtos;
+  }
+
+  async getCampersByCampId(campId: string): Promise<Array<CamperDTO>> {
+    let camperDtos: Array<CamperDTO> = [];
+
+    try {
+      const existingCamp: Camp | null = await MgCamp.findById(campId).populate({
+        path: "campers",
+        model: MgCamper,
+      });
+
+      if (!existingCamp) {
+        throw new Error(`Camp ${existingCamp} not found.`);
+      }
+
+      const campers = existingCamp.campers as Camper[];
+
+      camperDtos = campers.map((camper) => {
+        return {
+          id: camper.id,
+          firstName: camper.firstName,
+          lastName: camper.lastName,
+          age: camper.age,
+          contactName: camper.contactName,
+          contactEmail: camper.contactEmail,
+          contactNumber: camper.contactNumber,
+          camp: camper.camp ? camper.camp.toString() : "",
+          hasCamera: camper.hasCamera,
+          hasLaptop: camper.hasLaptop,
+          allergies: camper.allergies,
+          additionalDetails: camper.additionalDetails,
+          dropOffType: camper.dropOffType,
+          registrationDate: camper.registrationDate,
+          hasPaid: camper.hasPaid,
+          chargeId: camper.chargeId,
+        };
+      });
+    } catch (error: unknown) {
+      Logger.error(`Failed to get campers. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    return camperDtos;
+  }
 }
 
 export default CamperService;

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -8,6 +8,21 @@ interface ICamperService {
    * @throws Error if user creation fails
    */
   createCamper(camper: CreateCamperDTO): Promise<CamperDTO>;
+
+  /**
+   * Get all campers and their information
+   * @returns array of CamperDTOs
+   * @throws Error if camper retrieval fails
+   */
+  getAllCampers(): Promise<Array<CamperDTO>>;
+
+  /**
+   * Get campers associated with camp id
+   * @param campId camp's id
+   * @returns array of CamperDTOs
+   * @throws Error if camper retrieval fails
+   */
+  getCampersByCampId(campId: string): Promise<Array<CamperDTO>>;
 }
 
 export default ICamperService;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-38b49f83f6ce4b07ae188dabb37631e8?p=021b3b1505964056bbe9c30290d73a44)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `camper/campers` route which allows querying for all campers or only campers that belong to a camp, if the `campId` parameter is given


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test manually in Postman - create a GET request to `/camper/campers` with no `campId` parameter and ensure no errors in console logs, and also that all the campers belonging to the mongoDB database are returned
2. Create a GET request to `camper/campers` with a valid, existing `campId` parameter and ensure no errors + only campers that belong to the camp are returned
3. Add in a `campId` parameter for a camp that doesn't exist and ensure that error message is returned with status 500.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Error handling on getting campers code or any edge cases that may cause the service to break


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
