### PR TITLE
feat: registration api capacity check

### DIFF
--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -13,6 +13,20 @@ class CamperService implements ICamperService {
     let newCamper: Camper;
     let existingCamp: Camp | null;
     try {
+      existingCamp = await MgCamp.findById(camper.camp);
+
+      if (existingCamp) {
+        const existingCampObj = existingCamp.toObject();
+
+        if (existingCamp.campers.length >= existingCampObj.capacity) {
+          throw new Error(
+            `Error: camp is full. Current number of campers in camp: ${existingCamp.campers.length}. Camp capacity: ${existingCampObj.capacity}.`,
+          );
+        }
+      } else {
+        throw new Error(`Camp ${camper.camp} not found.`);
+      }
+
       newCamper = await MgCamper.create({
         camp: camper.camp,
         registrationDate: camper.registrationDate,

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -16,11 +16,9 @@ class CamperService implements ICamperService {
       existingCamp = await MgCamp.findById(camper.camp);
 
       if (existingCamp) {
-        const existingCampObj = existingCamp.toObject();
-
-        if (existingCamp.campers.length >= existingCampObj.capacity) {
+        if (existingCamp.campers.length >= existingCamp.capacity) {
           throw new Error(
-            `Error: camp is full. Current number of campers in camp: ${existingCamp.campers.length}. Camp capacity: ${existingCampObj.capacity}.`,
+            `Error: camp is full. Current number of campers in camp: ${existingCamp.campers.length}. Camp capacity: ${existingCamp.capacity}.`,
           );
         }
       } else {


### PR DESCRIPTION
## Notion ticket link
[Registration API: capacity check](https://uwblueprintexecs.notion.site/Registration-API-capacity-check-136ccc0ae90f4169a8e37351bb5ad302)


## Implementation description
* Added camp capacity check to create camper service


## Steps to test
1. Make a new POST request at http://localhost:5000/camper/register
2. Set the camp field to a camp that's full --> request should through an error stating "Error: camp is full" 
3. Set the camp field to a camp that's not full --> request should return request body as expected 


## What should reviewers focus on?
* Are the error messages formatted correctly? 
* Is there a more efficient way to do this? 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
