### PR TITLE
feat: delete camper by camper ID API

### DIFF
--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -66,10 +66,20 @@ camperRouter.get("/", async (req, res) => {
   }
 });
 
-/* Delete all campers with the chargeId with */
+/* Delete all campers with the chargeId */
 camperRouter.delete("/cancel/:chargeId", async (req, res) => {
   try {
     await camperService.deleteCampersByChargeId(req.params.chargeId);
+    res.status(204).send();
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+/* Delete a camper */
+camperRouter.delete("/:camperId", async (req, res) => {
+  try {
+    await camperService.deleteCamperById(req.params.camperId);
     res.status(204).send();
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -197,6 +197,56 @@ class CamperService implements ICamperService {
       throw error;
     }
   }
+
+  async deleteCamperById(camperId: string): Promise<void> {
+    try {
+      const camper: Camper | null = await MgCamper.findById(camperId);
+
+      if (!camper) {
+        throw new Error(`Camper with camper ID ${camperId} not found.`);
+      }
+
+      const camp: Camp | null = await MgCamp.findById(camper.camp);
+
+      if (!camp) {
+        throw new Error(`Camper's camp with campId ${camper.camp} not found.`);
+      }
+
+      // delete the camper from the camp's list of campers
+      const oldCamperIds = [...camp.campers];
+      camp.campers = camp.campers.filter((id) => id.toString() !== camperId);
+      await camp.save();
+
+      try {
+        await MgCamper.deleteOne({
+          _id: camperId,
+        });
+      } catch (mongoDbError: unknown) {
+        // could not delete camper, rollback camp's campers deletion
+        try {
+          camp.campers = oldCamperIds;
+          await camp.save();
+        } catch (rollbackDbError: unknown) {
+          const errorMessage = [
+            "Failed to rollback MongoDB camp's updated campers field after deleting camper document failure. Reason =",
+            getErrorMessage(rollbackDbError),
+            "MongoDB camper id that could not be deleted =",
+            camperId,
+          ];
+          Logger.error(errorMessage.join(" "));
+        }
+
+        throw mongoDbError;
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete camper with camper ID ${camperId}. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default CamperService;

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -30,6 +30,13 @@ interface ICamperService {
    * @throws Error if camper cancellation fails
    */
   deleteCampersByChargeId(chargeId: string): void;
+
+  /**
+   * Delete camper associated with the camper ID
+   * @param camperId camper's Id
+   * @throws Error if camper cancellation fails
+   */
+  deleteCamperById(camperId: string): void;
 }
 
 export default ICamperService;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Tasks-38b49f83f6ce4b07ae188dabb37631e8?p=b9d06121a6a34f27ae174e3adfed252c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `camper/:camperId` route allowing for an admin user to delete a camper by the camper ID
* This endpoint will delete the camper from the campers collection in the database and the campers field of the camper's camp


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Similar to https://github.com/uwblueprint/focus-on-nature/pull/24 , want to test manually by creating a DELETE request to the endpoint with camper ID
2. Test multiple cases: if the camper ID doesn't exist, the camp associated with the camper doesn't exist, test if the camper deletion throws an error then should rollback, test if rollback throws an error, and test a valid camper ID.
3. Note that these cases are already tested ^


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Verifying the logic/error handling logic for if a camper deletion doesn't work, etc.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
