### PR TITLE
feat: issue Stripe refund when camper is deleted

### DIFF
--- a/backend/typescript/middlewares/validators/camperValidators.ts
+++ b/backend/typescript/middlewares/validators/camperValidators.ts
@@ -233,3 +233,30 @@ export const updateCamperDtoValidator = async (
   }
   return next();
 };
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable-next-line import/prefer-default-export */
+export const cancelCamperDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.body.chargeId && !validatePrimitive(req.body.chargeId, "string")) {
+    return res.status(400).send(getApiValidationError("chargeId", "string"));
+  }
+  if (req.body.camperIds) {
+    if (req.body.camperIds.length === 0) {
+      return res
+        .status(400)
+        .send("There must be at least one camperId specified.");
+    }
+    for (let i = 0; i < req.body.camperIds.length; i += 1) {
+      if (!validatePrimitive(req.body.camperIds[i], "string")) {
+        return res
+          .status(400)
+          .send(getApiValidationError("camperIds", "string"));
+      }
+    }
+  }
+  return next();
+};

--- a/backend/typescript/package.json
+++ b/backend/typescript/package.json
@@ -40,6 +40,7 @@
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.5.0",
     "sequelize-typescript": "^2.1.0",
+    "stripe": "^8.212.0",
     "swagger-ui-express": "^4.1.6",
     "ts-node": "^10.0.0",
     "umzug": "^3.0.0-beta.16",

--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import { isAuthorizedByRole } from "../middlewares/auth";
 import {
+  cancelCamperDtoValidator,
   createCamperDtoValidator,
   updateCamperDtoValidator,
 } from "../middlewares/validators/camperValidators";
@@ -153,10 +154,13 @@ camperRouter.put(
   },
 );
 
-/* Delete all campers with the chargeId */
-camperRouter.delete("/cancel/:chargeId", async (req, res) => {
+/* Delete list of campers with the chargeId */
+camperRouter.delete("/cancel", cancelCamperDtoValidator, async (req, res) => {
   try {
-    await camperService.deleteCampersByChargeId(req.params.chargeId);
+    await camperService.deleteCampersByChargeId(
+      req.body.chargeId,
+      req.body.camperIds,
+    );
     res.status(204).send();
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -66,18 +66,19 @@ interface ICamperService {
   ): Promise<CamperDTO>;
 
   /**
-   * Delete all campers associated with the charge ID
+   * Delete all campers in camperIds associated with the charge ID
    * @param chargeId the charge ID for the payment
+   * @param camperIds the camper IDs to be deleted
    * @throws Error if camper cancellation fails
    */
-  deleteCampersByChargeId(chargeId: string): void;
+  deleteCampersByChargeId(chargeId: string, camperIds: string[]): Promise<void>;
 
   /**
-   * Delete camper associated with the camper ID
+   * Delete camper associated with the camper ID, without issuing refund
    * @param camperId camper's Id
    * @throws Error if camper cancellation fails
    */
-  deleteCamperById(camperId: string): void;
+  deleteCamperById(camperId: string): Promise<void>;
 }
 
 export default ICamperService;

--- a/backend/typescript/yarn.lock
+++ b/backend/typescript/yarn.lock
@@ -1234,6 +1234,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
   integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
 
+"@types/node@>=8.1.0":
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+
 "@types/node@^10.1.0":
   version "10.17.56"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.56.tgz#010c9e047c3ff09ddcd11cbb6cf5912725cdc2b3"
@@ -5706,6 +5711,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.6.0:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
@@ -6058,6 +6070,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 sift@16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/sift/-/sift-16.0.0.tgz#447991577db61f1a8fab727a8a98a6db57a23eb8"
@@ -6323,6 +6344,14 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stripe@^8.212.0:
+  version "8.212.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.212.0.tgz#78dc8d2be770580be23a8e597641a9ace6fd1035"
+  integrity sha512-xQ2uPMRAmRyOiMZktw3hY8jZ8LFR9lEQRPEaQ5WcDcn51kMyn46GeikOikxiFTHEN8PeKRdwtpz4yNArAvu/Kg==
+  dependencies:
+    "@types/node" ">=8.1.0"
+    qs "^6.6.0"
 
 stubs@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Tasks-38b49f83f6ce4b07ae188dabb37631e8?p=1a6a18a0dfb24ceeabba62338e200e57)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added call to Stripe API to refund and delete users based on charge ID and a given list of camper IDs
* Partial refunds can be done, depending on the given camper IDs to delete and the amount paid for each camper
* Note that currently the secret key being used is the test key (test transactions), and will need to be updated when the project is deployed


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Register a new camper so that they are added to the database, and create a test Payment Intent to the Stripe account. There is no code for this yet but you can try running this code before creating the camper, using the generated charge ID for registration:
```
const paymentIntent = await stripe.paymentIntents.create({
        amount: 2000,
         currency: "cad",
         payment_method_types: ["card"],
       });
       const confirmedPaymentIntent = await stripe.paymentIntents.confirm(
         paymentIntent.id,
         { payment_method: "pm_card_visa" },
       );

  const chargeId = confirmedPaymentIntent.charges.data[0].id; 
```
Note that you can register multiple campers under the same charge ID.
2. Using the charge ID, call the `/cancel` endpoint and pass in the charge ID from above, as well as a list of all the campers you want to refund
3. Check the Stripe dashboard to ensure that the payment was made and then refunded (see screenshots)
4. Note that if you want to do partial refunds, the payment in Stripe will be moved to the Refunds section but with only a partial refund.

There are some cases to look for/test:
* When you pass in an empty list of camper IDs, should throw error
* When you pass in a charge ID that doesn't exist or one that does exist but some/all camper IDs do not have such a charge ID, should throw error
* When the amount that you want to refund is larger than the amount in the original payment (usually this happens if there was an error with registration where the `charges` field in the created campers don't add up to the amount in Stripe
* Ensure that in Stripe, when a partial refund is made, the amount refunded is updated/reflected in the Stripe dashboard


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensuring all cases pass and there aren't any extra cases that haven't been covered


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

## Screenshots
New payment
![image](https://user-images.githubusercontent.com/64325829/160964211-fb9ae5f6-0203-4b68-a3b9-6a6e246bd12f.png)

Refunded payment
![image](https://user-images.githubusercontent.com/64325829/160964931-99472fa8-3cea-431a-a8f8-380f5867f667.png)



