### PR TITLE
feat: add capacity check on campsession update

### DIFF
--- a/backend/typescript/models/campSession.model.ts
+++ b/backend/typescript/models/campSession.model.ts
@@ -7,7 +7,7 @@ export interface CampSession extends Document {
   active: boolean;
   camp: Schema.Types.ObjectId;
   capacity: number;
-  campers: (Camper | Schema.Types.ObjectId)[];
+  campers: (Camper | Schema.Types.ObjectId | string)[];
   dates: Date[];
   endTime: string;
   priceId: string;
@@ -38,6 +38,12 @@ const CampSessionSchema: Schema = new Schema({
       },
     ],
     default: [],
+    validate: [
+      function (this: any, value: any) {
+        return value.length <= this.capacity;
+      },
+      "Camp is at maximum capacity",
+    ],
   },
   dates: {
     type: [Date],

--- a/backend/typescript/models/campSession.model.ts
+++ b/backend/typescript/models/campSession.model.ts
@@ -42,7 +42,7 @@ const CampSessionSchema: Schema = new Schema({
       function (this: any, value: any) {
         return value.length <= this.capacity;
       },
-      "Camp is at maximum capacity",
+      "Capacity error - tried to register for more spots than available",
     ],
   },
   dates: {

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -37,20 +37,21 @@ class CamperService implements ICamperService {
       if (campers.length > 0) {
         try {
           newCamperIds = newCampers.map((newCamper) => newCamper.id);
-          existingCampSession = await MgCampSession.findByIdAndUpdate(
+          existingCampSession = await MgCampSession.findById(
             campers[0].campSession,
-            {
-              $push: { campers: newCamperIds },
-            },
-            {
-              runValidators: true,
-            },
           );
+
           if (!existingCampSession) {
             throw new Error(
               `Camp session ${campers[0].campSession} not found.`,
             );
           }
+
+          existingCampSession.campers = existingCampSession.campers
+            .map((id) => id.toString())
+            .concat(newCamperIds);
+          await existingCampSession.save();
+
           const camp = await MgCamp.findById(existingCampSession.camp);
           if (!camp) {
             throw new Error(`Camp ${existingCampSession.camp} not found.`);


### PR DESCRIPTION
## Notion ticket link
[Registration API - capacity check enhancement](https://uwblueprintexecs.notion.site/Registration-API-capacity-check-enhancement-8ad08840bd72465a8a9b2732c18a3487)


## Implementation description
* moved camp capacity validation from camperService to camper.model
* this change was implemented to prevent race conditions from occurring upon registering a new camper to a camp session


## Steps to test
1. Make a new POST request at http://localhost:5000/camper/register
2. Set the campSession field to a camp that's full --> request should through an error stating "Error: camp is full"
3. Set the campSession field to a camp that's not full --> request should return request body as expected


## What should reviewers focus on?
* Are the error messages formatted correctly?
* Is there a more efficient way to do this?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
