### PR TITLE
fix: moved capacity to campSession

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -45,9 +45,6 @@ export const createCampDtoValidator = async (
   if (body.ageUpper < body.ageLower) {
     return res.status(400).send("ageUpper must be larger than ageLower");
   }
-  if (!validatePrimitive(body.capacity, "integer")) {
-    return res.status(400).send(getApiValidationError("capacity", "integer"));
-  }
   if (!validatePrimitive(body.fee, "integer")) {
     return res.status(400).send(getApiValidationError("fee", "integer"));
   }
@@ -68,6 +65,11 @@ export const createCampDtoValidator = async (
   if (body.campSessions) {
     for (let i = 0; i < body.campSessions.length; i += 1) {
       const campSession = body.campSessions[i];
+      if (!validatePrimitive(campSession.capacity, "integer")) {
+        return res
+          .status(400)
+          .send(getApiValidationError("capacity", "integer"));
+      }
       if (campSession.dates && !validateArray(campSession.dates, "string")) {
         return res
           .status(400)

--- a/backend/typescript/models/camp.model.ts
+++ b/backend/typescript/models/camp.model.ts
@@ -6,7 +6,6 @@ export interface Camp extends Document {
   id: string;
   ageLower: number;
   ageUpper: number;
-  capacity: number;
   campSessions: (Schema.Types.ObjectId | CampSession)[];
   description: string;
   fee: number;
@@ -23,10 +22,6 @@ const CampSchema: Schema = new Schema({
     required: true,
   },
   ageUpper: {
-    type: Number,
-    required: true,
-  },
-  capacity: {
     type: Number,
     required: true,
   },

--- a/backend/typescript/models/campSession.model.ts
+++ b/backend/typescript/models/campSession.model.ts
@@ -28,7 +28,7 @@ const CampSessionSchema: Schema = new Schema({
   capacity: {
     type: Number,
     required: true,
-    default: 0, 
+    default: 0,
   },
   campers: {
     type: [

--- a/backend/typescript/models/campSession.model.ts
+++ b/backend/typescript/models/campSession.model.ts
@@ -6,6 +6,7 @@ export interface CampSession extends Document {
   id: string;
   active: boolean;
   camp: Schema.Types.ObjectId;
+  capacity: number;
   campers: (Camper | Schema.Types.ObjectId)[];
   dates: Date[];
   endTime: string;
@@ -23,6 +24,11 @@ const CampSessionSchema: Schema = new Schema({
     type: Schema.Types.ObjectId,
     ref: "Camp",
     required: true,
+  },
+  capacity: {
+    type: Number,
+    required: true,
+    default: 0, 
   },
   campers: {
     type: [

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -42,7 +42,6 @@ campRouter.post(
         name: body.name,
         description: body.description,
         location: body.location,
-        capacity: body.capacity,
         fee: body.fee,
         formQuestions: body.formQuestions,
         campSessions: body.campSessions,

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -21,7 +21,7 @@ const testCamps: CreateCampDTO[] = [
     fee: 25,
     campSessions: [
       {
-        capacity: 20, 
+        capacity: 20,
         active: true,
         startTime: "12:00",
         endTime: "17:00",
@@ -46,7 +46,7 @@ const testCamps: CreateCampDTO[] = [
     fee: 24,
     campSessions: [
       {
-        capacity: 20, 
+        capacity: 20,
         active: true,
         startTime: "1:00",
         endTime: "2:00",
@@ -144,7 +144,6 @@ describe("mongo campService", (): void => {
 
       expect(res.ageLower).toEqual(testCamp.ageLower);
       expect(res.ageUpper).toEqual(testCamp.ageUpper);
-      expect(res.capacity).toEqual(testCamp.capacity);
       expect(res.name).toEqual(testCamp.name);
       expect(res.description).toEqual(testCamp.description);
       expect(res.location).toEqual(testCamp.location);

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -18,10 +18,10 @@ const testCamps: CreateCampDTO[] = [
     name: "test camp",
     description: "description",
     location: "canada",
-    capacity: 20,
     fee: 25,
     campSessions: [
       {
+        capacity: 20, 
         active: true,
         startTime: "12:00",
         endTime: "17:00",
@@ -43,10 +43,10 @@ const testCamps: CreateCampDTO[] = [
     name: "test camp2",
     description: "description2",
     location: "canada",
-    capacity: 500,
     fee: 24,
     campSessions: [
       {
+        capacity: 20, 
         active: true,
         startTime: "1:00",
         endTime: "2:00",

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -57,7 +57,7 @@ class CampService implements ICampService {
 
         const campSessions = (camp.campSessions as CampSession[]).map(
           (campSession) => ({
-            capacity: campSession.capacity, 
+            capacity: campSession.capacity,
             dates: campSession.dates.map((date) => date.toString()),
             startTime: campSession.startTime,
             endTime: campSession.endTime,
@@ -197,7 +197,7 @@ class CampService implements ICampService {
         camp.campSessions.map(async (campSession, i) => {
           const session = await MgCampSession.create({
             camp: newCamp,
-            capacity: campSession.capacity, 
+            capacity: campSession.capacity,
             campers: [],
             waitlist: [],
             startTime: campSession.startTime,

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -57,6 +57,7 @@ class CampService implements ICampService {
 
         const campSessions = (camp.campSessions as CampSession[]).map(
           (campSession) => ({
+            capacity: campSession.capacity, 
             dates: campSession.dates.map((date) => date.toString()),
             startTime: campSession.startTime,
             endTime: campSession.endTime,
@@ -70,7 +71,6 @@ class CampService implements ICampService {
           id: camp.id,
           ageLower: camp.ageLower,
           ageUpper: camp.ageUpper,
-          capacity: camp.capacity,
           name: camp.name,
           description: camp.description,
           location: camp.location,
@@ -173,7 +173,6 @@ class CampService implements ICampService {
         name: camp.name,
         ageLower: camp.ageLower,
         ageUpper: camp.ageUpper,
-        capacity: camp.capacity,
         description: camp.description,
         location: camp.location,
         fee: camp.fee,
@@ -198,6 +197,7 @@ class CampService implements ICampService {
         camp.campSessions.map(async (campSession, i) => {
           const session = await MgCampSession.create({
             camp: newCamp,
+            capacity: campSession.capacity, 
             campers: [],
             waitlist: [],
             startTime: campSession.startTime,
@@ -248,7 +248,6 @@ class CampService implements ICampService {
       ageLower: newCamp.ageLower,
       ageUpper: newCamp.ageUpper,
       campSessions: newCamp.campSessions.map((session) => session.toString()),
-      capacity: newCamp.capacity,
       name: newCamp.name,
       description: newCamp.description,
       location: newCamp.location,

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -83,6 +83,7 @@ export type RegisterUserDTO = Omit<CreateUserDTO, "role">;
 export type CampSessionDTO = {
   id: string;
   camp: string;
+  capacity: number;
   campers: string[];
   waitlist: string[];
   dates: string[];
@@ -95,7 +96,6 @@ export type CampDTO = {
   id: string;
   ageLower: number;
   ageUpper: number;
-  capacity: number;
   name: string;
   description: string;
   location: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp model update](https://uwblueprintexecs.notion.site/Camp-model-update-b4bccf767f484ae7b2a4ec03e34f7f69)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* moved capacity field from camp to campSession 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. make a post request at `http://localhost:5000/camp`
Sample request body: 
```
{
        "ageLower": 10,
        "ageUpper": 22,
        "name": "hihi",
        "description": "test",
        "location": "canada",
        "fee": 20,
        "formQuestions": [
            {
                "id": "6229700fc097b201b8edb3e6",
                "type": "Text",
                "question": "question test",
                "required": true,
                "description": "this is the description for question test",
                "options": []
            }
        ],
        "campSessions": [
            {
                "capacity": 42,
                "dates": [
                    "Thu Dec 02 2021 00:00:00 GMT+0000 (Coordinated Universal Time)",
                    "Thu Dec 30 2021 00:00:00 GMT+0000 (Coordinated Universal Time)"
                ],
                "startTime": "12:40",
                "endTime": "16:50",
                "registrations": 0,
                "waitlist": 0,
                "active": true
            },
            {
                "capacity": 43,
                "dates": [
                    "Mon Mar 14 2022 02:01:14 GMT+0000 (Coordinated Universal Time)"
                ],
                "startTime": "12:00",
                "endTime": "17:00",
                "registrations": 0,
                "waitlist": 0,
                "active": true
            },
            {
                "capacity": 44,
                "dates": [
                    "Mon Mar 14 2022 02:01:14 GMT+0000 (Coordinated Universal Time)"
                ],
                "startTime": "12:00",
                "endTime": "20:00",
                "registrations": 0,
                "waitlist": 0,
                "active": false
            }
        ]
}
```
2. make sure to select "form-data" in postman with the key set to "data" and the corresponding value to the request body (example is shown below)
<img width="1021" alt="Screen Shot 2022-05-14 at 3 55 24 PM" src="https://user-images.githubusercontent.com/46568041/168446485-496f48ea-1aca-4937-855a-2638fc04cb15.png">
3. verify new camp and campSessions were created in mongo 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* are there other properties capacity affects that should be addressed? 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
