### PR TITLE
fix: prevent inactive users from signing in

### DIFF
--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -58,8 +58,6 @@ class AuthService implements IAuthService {
       try {
         // Note: an error message will be logged from UserService if this lookup fails.
         // You may want to silence the logger for this special OAuth user lookup case
-        // return { ...token, ...user };
-        /* eslint-disable-next-line no-empty */
         user = await this.userService.getUserByEmail(googleUser.email);
       } catch (error) {
         Logger.error(error as string);

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -8,7 +8,6 @@ import { getErrorMessage } from "../../utilities/errorUtils";
 import FirebaseRestClient from "../../utilities/firebaseRestClient";
 import logger from "../../utilities/logger";
 import { validateUserEmail } from "../../middlewares/validators/util";
-import { User } from "../../models/user.model";
 
 const Logger = logger(__filename);
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Verify access management ](https://www.notion.so/uwblueprintexecs/Task-Board-S22-1a3e651ab8544192bf0fdcbba04f6d03?p=ab3e8dc45b3e4a56af7e7bb95405f5ef)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Check `active` field on user if the user already exists. If `active` is false, they should not be able to sign in.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test signing in with `active` as both true and false on your user account. You may have to delete local storage to be able to log out properly.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* nature! :D  


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
