### PR TITLE
feat: add delete camp endpoint

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -33,6 +33,43 @@ export const createCampDtoValidator = async (
   if (body.description && !validatePrimitive(body.description, "string")) {
     return res.status(400).send(getApiValidationError("description", "string"));
   }
+  if (!validatePrimitive(body.earlyDropoff, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("earlyDropoff", "string"));
+  }
+  if (!validateTime(body.earlyDropoff)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("earlyDropoff", "24 hr time string"));
+  }
+  if (!validatePrimitive(body.latePickup, "string")) {
+    return res.status(400).send(getApiValidationError("latePickup", "string"));
+  }
+  if (!validateTime(body.latePickup)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("latePickup", "24 hr time string"));
+  }
+  if (!validatePrimitive(body.startTime, "string")) {
+    return res.status(400).send(getApiValidationError("startTime", "string"));
+  }
+  if (!validateTime(body.startTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("startTime", "24 hr time string"));
+  }
+  if (!validatePrimitive(body.endTime, "string")) {
+    return res.status(400).send(getApiValidationError("endTime", "string"));
+  }
+  if (!validateTime(body.endTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("endTime", "24 hr time string"));
+  }
+  if (!validatePrimitive(body.active, "boolean")) {
+    return res.status(400).send(getApiValidationError("active", "boolean"));
+  }
   if (!validatePrimitive(body.location, "string")) {
     return res.status(400).send(getApiValidationError("location", "string"));
   }
@@ -42,16 +79,34 @@ export const createCampDtoValidator = async (
   if (!validatePrimitive(body.ageUpper, "integer")) {
     return res.status(400).send(getApiValidationError("ageUpper", "integer"));
   }
+  if (
+    body.campCoordinators &&
+    !validateArray(body.campCoordinators, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("campCoordinators", "string", true));
+  }
+  if (body.campCounsellors && !validateArray(body.campCounsellors, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("campCounsellors", "string", true));
+  }
+
   if (body.ageUpper < body.ageLower) {
     return res.status(400).send("ageUpper must be larger than ageLower");
   }
   if (!validatePrimitive(body.fee, "integer")) {
     return res.status(400).send(getApiValidationError("fee", "integer"));
   }
-  if (req.body.fee < 0) {
+  if (body.fee < 0) {
     return res.status(400).send("fee cannot be negative");
   }
-
+  if (body.volunteers && !validateArray(body.volunteers, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("volunteers", "string", true));
+  }
   if (
     body.formQuestions &&
     Array.isArray(body.formQuestions) &&
@@ -82,27 +137,6 @@ export const createCampDtoValidator = async (
         return res
           .status(400)
           .send(getApiValidationError("dates", "Date string"));
-      }
-      if (!validatePrimitive(campSession.startTime, "string")) {
-        return res
-          .status(400)
-          .send(getApiValidationError("startTime", "string"));
-      }
-      if (!validateTime(campSession.startTime)) {
-        return res
-          .status(400)
-          .send(getApiValidationError("startTime", "24 hr time string"));
-      }
-      if (!validatePrimitive(campSession.endTime, "string")) {
-        return res.status(400).send(getApiValidationError("endTime", "string"));
-      }
-      if (!validateTime(campSession.endTime)) {
-        return res
-          .status(400)
-          .send(getApiValidationError("endTime", "24 hr time string"));
-      }
-      if (!validatePrimitive(campSession.active, "boolean")) {
-        return res.status(400).send(getApiValidationError("active", "boolean"));
       }
     }
   }
@@ -151,8 +185,66 @@ export const updateCampDtoValidator = async (
   if (req.body.ageUpper < req.body.ageLower) {
     return res.status(400).send("ageUpper must be larger than ageLower");
   }
+  if (
+    req.body.campCoordinators &&
+    !validateArray(req.body.campCoordinators, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("campCoordinators", "string", true));
+  }
+  if (
+    req.body.campCounsellors &&
+    !validateArray(req.body.campCounsellors, "string")
+  ) {
+    return res
+      .status(400)
+      .send(getApiValidationError("campCounsellors", "string", true));
+  }
+  if (!validatePrimitive(req.body.earlyDropoff, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("earlyDropoff", "string"));
+  }
+  if (!validateTime(req.body.earlyDropoff)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("earlyDropoff", "24 hr time string"));
+  }
+  if (!validatePrimitive(req.body.latePickup, "string")) {
+    return res.status(400).send(getApiValidationError("latePickup", "string"));
+  }
+  if (!validateTime(req.body.latePickup)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("latePickup", "24 hr time string"));
+  }
+  if (!validatePrimitive(req.body.startTime, "string")) {
+    return res.status(400).send(getApiValidationError("startTime", "string"));
+  }
+  if (!validateTime(req.body.startTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("startTime", "24 hr time string"));
+  }
+  if (!validatePrimitive(req.body.endTime, "string")) {
+    return res.status(400).send(getApiValidationError("endTime", "string"));
+  }
+  if (!validateTime(req.body.endTime)) {
+    return res
+      .status(400)
+      .send(getApiValidationError("endTime", "24 hr time string"));
+  }
+  if (!validatePrimitive(req.body.active, "boolean")) {
+    return res.status(400).send(getApiValidationError("active", "boolean"));
+  }
   if (!validatePrimitive(req.body.fee, "integer")) {
     return res.status(400).send(getApiValidationError("fee", "integer"));
+  }
+  if (req.body.volunteers && !validateArray(req.body.volunteers, "string")) {
+    return res
+      .status(400)
+      .send(getApiValidationError("volunteers", "string", true));
   }
   if (req.body.fee < 0) {
     return res.status(400).send("fee cannot be negative");
@@ -186,27 +278,6 @@ export const createCampSessionsDtoValidator = async (
           .status(400)
           .send(getApiValidationError("dates", "Date string"));
       }
-      if (!validatePrimitive(campSession.startTime, "string")) {
-        return res
-          .status(400)
-          .send(getApiValidationError("startTime", "string"));
-      }
-      if (!validateTime(campSession.startTime)) {
-        return res
-          .status(400)
-          .send(getApiValidationError("startTime", "24 hr time string"));
-      }
-      if (!validatePrimitive(campSession.endTime, "string")) {
-        return res.status(400).send(getApiValidationError("endTime", "string"));
-      }
-      if (!validateTime(campSession.endTime)) {
-        return res
-          .status(400)
-          .send(getApiValidationError("endTime", "24 hr time string"));
-      }
-      if (!validatePrimitive(campSession.active, "boolean")) {
-        return res.status(400).send(getApiValidationError("active", "boolean"));
-      }
       if (!validatePrimitive(campSession.capacity, "integer")) {
         return res
           .status(400)
@@ -236,25 +307,6 @@ export const updateCampSessionDtoValidator = async (
   }
   if (!campSession.dates.every(validateDate)) {
     return res.status(400).send(getApiValidationError("dates", "Date string"));
-  }
-  if (!validatePrimitive(campSession.startTime, "string")) {
-    return res.status(400).send(getApiValidationError("startTime", "string"));
-  }
-  if (!validateTime(campSession.startTime)) {
-    return res
-      .status(400)
-      .send(getApiValidationError("startTime", "24 hr time string"));
-  }
-  if (!validatePrimitive(campSession.endTime, "string")) {
-    return res.status(400).send(getApiValidationError("endTime", "string"));
-  }
-  if (!validateTime(campSession.endTime)) {
-    return res
-      .status(400)
-      .send(getApiValidationError("endTime", "24 hr time string"));
-  }
-  if (!validatePrimitive(campSession.active, "boolean")) {
-    return res.status(400).send(getApiValidationError("active", "boolean"));
   }
   if (!validatePrimitive(campSession.capacity, "integer")) {
     return res.status(400).send(getApiValidationError("capacity", "integer"));

--- a/backend/typescript/middlewares/validators/camperValidators.ts
+++ b/backend/typescript/middlewares/validators/camperValidators.ts
@@ -4,7 +4,6 @@ import {
   validatePrimitive,
   validateDate,
   validateMap,
-  validateTime,
 } from "./util";
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
@@ -55,23 +54,33 @@ export const createCampersDtoValidator = async (
         .status(400)
         .send(getApiValidationError("hasLaptop", "boolean"));
     }
-    if (
-      camper.earlyDropoff &&
-      (!validatePrimitive(camper.earlyDropoff, "string") ||
-        !validateTime(camper.earlyDropoff))
-    ) {
-      return res
-        .status(400)
-        .send(getApiValidationError("earlyDropoff", "24 hr time string"));
+    if (!Array.isArray(camper.earlyDropoff)) {
+      return res.status(400).send("early dropoff is not an array");
     }
-    if (
-      camper.latePickup &&
-      (!validatePrimitive(camper.latePickup, "string") ||
-        !validateTime(camper.latePickup))
-    ) {
-      return res
-        .status(400)
-        .send(getApiValidationError("latePickup", "24 hr time string"));
+    // eslint-disable-next-line no-restricted-syntax
+    for (const dropoffDate of camper.earlyDropoff) {
+      if (
+        !validatePrimitive(dropoffDate, "string") ||
+        !validateDate(dropoffDate)
+      ) {
+        return res
+          .status(400)
+          .send(getApiValidationError("earlyDropoff", "Date string"));
+      }
+    }
+    if (!Array.isArray(camper.latePickup)) {
+      return res.status(400).send("late pickup is not an array");
+    }
+    // eslint-disable-next-line no-restricted-syntax
+    for (const pickupDate of camper.latePickup) {
+      if (
+        !validatePrimitive(pickupDate, "string") ||
+        !validateDate(pickupDate)
+      ) {
+        return res
+          .status(400)
+          .send(getApiValidationError("latePickup", "Date string"));
+      }
     }
     if (
       camper.specialNeeds &&
@@ -150,6 +159,22 @@ export const createCampersDtoValidator = async (
     } else {
       return res.status(400).send(getApiValidationError("charges", "mixed"));
     }
+    if (!Array.isArray(camper.optionalClauses)) {
+      return res.status(400).send("optional clauses must be an array");
+    }
+    // eslint-disable-next-line no-restricted-syntax
+    for (const optionalClause of camper.optionalClauses) {
+      if (!validatePrimitive(optionalClause.clause, "string")) {
+        return res
+          .status(400)
+          .send(getApiValidationError("optionalClause.clause", "string"));
+      }
+      if (!validatePrimitive(optionalClause.agreed, "boolean")) {
+        return res
+          .status(400)
+          .send(getApiValidationError("optionalClause.agreed", "boolean"));
+      }
+    }
   }
   return next();
 };
@@ -195,23 +220,33 @@ export const updateCamperDtoValidator = async (
   if (req.body.hasLaptop && !validatePrimitive(req.body.hasLaptop, "boolean")) {
     return res.status(400).send(getApiValidationError("hasLaptop", "boolean"));
   }
-  if (
-    req.body.earlyDropoff &&
-    (!validatePrimitive(req.body.earlyDropoff, "string") ||
-      !validateTime(req.body.earlyDropoff))
-  ) {
-    return res
-      .status(400)
-      .send(getApiValidationError("earlyDropoff", "24 hr time string"));
+  if (!Array.isArray(req.body.earlyDropoff)) {
+    return res.status(400).send("early dropoff is not an array");
   }
-  if (
-    req.body.latePickup &&
-    (!validatePrimitive(req.body.latePickup, "string") ||
-      !validateTime(req.body.latePickup))
-  ) {
-    return res
-      .status(400)
-      .send(getApiValidationError("latePickup", "24 hr time string"));
+  // eslint-disable-next-line no-restricted-syntax
+  for (const dropoffDate of req.body.earlyDropoff) {
+    if (
+      !validatePrimitive(dropoffDate, "Date string") ||
+      !validateDate(dropoffDate)
+    ) {
+      return res
+        .status(400)
+        .send(getApiValidationError("earlyDropoff", "Date string"));
+    }
+  }
+  if (!Array.isArray(req.body.latePickup)) {
+    return res.status(400).send("late pickup is not an array");
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const pickupDate of req.body.latePickup) {
+    if (
+      !validatePrimitive(pickupDate, "Date string") ||
+      !validateDate(pickupDate)
+    ) {
+      return res
+        .status(400)
+        .send(getApiValidationError("latePickup", "Date string"));
+    }
   }
   if (
     req.body.specialNeeds &&
@@ -264,6 +299,22 @@ export const updateCamperDtoValidator = async (
   }
   if (req.body.hasPaid && !validatePrimitive(req.body.hasPaid, "boolean")) {
     return res.status(400).send(getApiValidationError("hasPaid", "boolean"));
+  }
+  if (!Array.isArray(req.body.optionalClauses)) {
+    return res.status(400).send("optional clauses must be an array");
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const optionalClause of req.body.optionalClauses) {
+    if (!validatePrimitive(optionalClause.clause, "string")) {
+      return res
+        .status(400)
+        .send(getApiValidationError("optionalClause.clause", "string"));
+    }
+    if (!validatePrimitive(optionalClause.agreed, "boolean")) {
+      return res
+        .status(400)
+        .send(getApiValidationError("optionalClause.agreed", "boolean"));
+    }
   }
   return next();
 };

--- a/backend/typescript/middlewares/validators/util.ts
+++ b/backend/typescript/middlewares/validators/util.ts
@@ -82,7 +82,7 @@ export const validateDate = (value: string): boolean => {
 };
 
 export const validateTime = (value: string): boolean => {
-  const regex = new RegExp("^([01][0-9]|2[0-3]):([0-5][0-9])$");
+  const regex = new RegExp("^([01]?[0-9]|2[0-3]):([0-5][0-9])$");
   return regex.test(value);
 };
 

--- a/backend/typescript/models/camp.model.ts
+++ b/backend/typescript/models/camp.model.ts
@@ -1,22 +1,35 @@
 import { Schema, Document, model } from "mongoose";
 import { CampSession } from "./campSession.model";
 import { FormQuestion } from "./formQuestion.model";
+import { User } from "./user.model";
 
 export interface Camp extends Document {
   id: string;
+  active: boolean;
   ageLower: number;
   ageUpper: number;
+  campCoordinators: (User | Schema.Types.ObjectId)[];
+  campCounsellors: (User | Schema.Types.ObjectId)[];
   campSessions: (Schema.Types.ObjectId | CampSession)[];
   description: string;
+  earlyDropoff: string;
+  endTime: string;
   fee: number;
   fileName?: string;
   formQuestions: (Schema.Types.ObjectId | FormQuestion)[];
+  latePickup: string;
   location: string;
   name: string;
+  startTime: string;
   productId: string;
+  volunteers: string[];
 }
 
 const CampSchema: Schema = new Schema({
+  active: {
+    type: Boolean,
+    required: true,
+  },
   ageLower: {
     type: Number,
     required: true,
@@ -24,6 +37,24 @@ const CampSchema: Schema = new Schema({
   ageUpper: {
     type: Number,
     required: true,
+  },
+  campCoordinators: {
+    type: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+    default: [],
+  },
+  campCounsellors: {
+    type: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+    default: [],
   },
   campSessions: {
     type: [
@@ -35,6 +66,13 @@ const CampSchema: Schema = new Schema({
     default: [],
   },
   description: {
+    type: String,
+  },
+  endTime: {
+    type: String,
+    required: true,
+  },
+  earlyDropoff: {
     type: String,
   },
   fee: {
@@ -54,6 +92,9 @@ const CampSchema: Schema = new Schema({
     default: [],
     required: true,
   },
+  latePickup: {
+    type: String,
+  },
   location: {
     type: String,
     required: true,
@@ -64,6 +105,18 @@ const CampSchema: Schema = new Schema({
   },
   productId: {
     type: String,
+  },
+  startTime: {
+    type: String,
+    required: true,
+  },
+  volunteers: {
+    type: [
+      {
+        type: String,
+      },
+    ],
+    default: [],
   },
 });
 

--- a/backend/typescript/models/campSession.model.ts
+++ b/backend/typescript/models/campSession.model.ts
@@ -4,22 +4,15 @@ import { WaitlistedCamper } from "./waitlistedCamper.model";
 
 export interface CampSession extends Document {
   id: string;
-  active: boolean;
   camp: Schema.Types.ObjectId;
   capacity: number;
   campers: (Camper | Schema.Types.ObjectId | string)[];
   dates: Date[];
-  endTime: string;
   priceId: string;
-  startTime: string;
   waitlist: (WaitlistedCamper | Schema.Types.ObjectId)[];
 }
 
 const CampSessionSchema: Schema = new Schema({
-  active: {
-    type: Boolean,
-    required: true,
-  },
   camp: {
     type: Schema.Types.ObjectId,
     ref: "Camp",
@@ -49,16 +42,8 @@ const CampSessionSchema: Schema = new Schema({
     type: [Date],
     required: true,
   },
-  endTime: {
-    type: String,
-    required: true,
-  },
   priceId: {
     type: String,
-  },
-  startTime: {
-    type: String,
-    required: true,
   },
   waitlist: {
     type: [

--- a/backend/typescript/models/camper.model.ts
+++ b/backend/typescript/models/camper.model.ts
@@ -9,8 +9,8 @@ export interface Camper extends Document {
   allergies: string;
   hasCamera: boolean;
   hasLaptop: boolean;
-  earlyDropoff: string;
-  latePickup: string;
+  earlyDropoff: Date[];
+  latePickup: Date[];
   specialNeeds: string;
   contacts: {
     firstName: string;
@@ -27,6 +27,12 @@ export interface Camper extends Document {
     earlyDropoff: number;
     latePickup: number;
   };
+  optionalClauses: [
+    {
+      clause: string;
+      agreed: boolean;
+    },
+  ];
 }
 
 const CamperSchema: Schema = new Schema({
@@ -56,12 +62,8 @@ const CamperSchema: Schema = new Schema({
   hasLaptop: {
     type: Boolean,
   },
-  earlyDropoff: {
-    type: String,
-  },
-  latePickup: {
-    type: String,
-  },
+  earlyDropoff: [Date],
+  latePickup: [Date],
   specialNeeds: {
     type: String,
   },
@@ -118,6 +120,16 @@ const CamperSchema: Schema = new Schema({
       required: true,
     },
   },
+  optionalClauses: [
+    {
+      clause: {
+        type: String,
+      },
+      agreed: {
+        type: Boolean,
+      },
+    },
+  ],
 });
 
 export default mongoose.model<Camper>("Camper", CamperSchema);

--- a/backend/typescript/models/waitlistedCamper.model.ts
+++ b/backend/typescript/models/waitlistedCamper.model.ts
@@ -1,4 +1,5 @@
 import mongoose, { Schema, Document } from "mongoose";
+import { WaitlistedCamperStatus } from "../types";
 
 export interface WaitlistedCamper extends Document {
   id: string;
@@ -8,6 +9,7 @@ export interface WaitlistedCamper extends Document {
   contactName: string;
   contactEmail: string;
   contactNumber: string;
+  status: WaitlistedCamperStatus;
   campSession: Schema.Types.ObjectId;
 }
 
@@ -34,6 +36,12 @@ const WaitlistedCamperSchema: Schema = new Schema({
   },
   contactNumber: {
     type: String,
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["NotRegistered", "RegistrationFormSent", "Registered"],
+    default: "NotRegistered",
     required: true,
   },
   campSession: {

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -51,17 +51,26 @@ campRouter.post(
     try {
       const body = JSON.parse(req.body.data);
       const newCamp = await campService.createCamp({
+        active: body.active,
         ageLower: body.ageLower,
         ageUpper: body.ageUpper,
+        campCoordinators: body.campCoordinators,
+        campCounsellors: body.campCounsellors,
+        campSessions: body.campSessions,
         name: body.name,
         description: body.description,
+        earlyDropoff: body.earlyDropoff,
+        latePickup: body.latePickup,
         location: body.location,
         fee: body.fee,
         formQuestions: body.formQuestions,
-        campSessions: body.campSessions,
         filePath: req.file?.path,
         fileContentType: req.file?.mimetype,
+        startTime: body.startTime,
+        endTime: body.endTime,
+        volunteers: body.volunteers,
       });
+
       if (req.file?.path) {
         fs.unlinkSync(req.file.path);
       }
@@ -76,12 +85,20 @@ campRouter.post(
 campRouter.patch("/:campId", updateCampDtoValidator, async (req, res) => {
   try {
     const newCamp = await campService.updateCampById(req.params.campId, {
+      active: req.body.active,
       ageLower: req.body.ageLower,
       ageUpper: req.body.ageUpper,
+      campCoordinators: req.body.campCoordinators,
+      campCounsellors: req.body.campCounsellors,
       name: req.body.name,
       description: req.body.description,
+      earlyDropoff: req.body.earlyDropoff,
+      latePickup: req.body.latePickup,
       location: req.body.location,
       fee: req.body.fee,
+      startTime: req.body.startTime,
+      endTime: req.body.endTime,
+      volunteers: req.body.volunteers,
     });
 
     res.status(200).json(newCamp);
@@ -119,9 +136,6 @@ campRouter.patch(
         {
           capacity: req.body.capacity,
           dates: req.body.dates,
-          startTime: req.body.startTime,
-          endTime: req.body.endTime,
-          active: req.body.active,
         },
       );
       res.status(200).json(campSession);

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -168,4 +168,14 @@ campRouter.get("/csv/:id", async (req, res) => {
   }
 });
 
+/* Delete a camp */
+campRouter.delete("/:id", async (req, res) => {
+  try {
+    await campService.deleteCamp(req.params.id);
+    res.status(204).send();
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 export default campRouter;

--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -97,6 +97,7 @@ camperRouter.post(
         contactEmail: req.body.contactEmail,
         contactNumber: req.body.contactNumber,
         campSession: req.body.campSession,
+        status: "NotRegistered",
       });
 
       res.status(201).json(newWaitlistedCamper);
@@ -105,6 +106,20 @@ camperRouter.post(
     }
   },
 );
+
+camperRouter.patch("/waitlist/:waitlistedCamperId", async (req, res) => {
+  try {
+    const updatedWaitlistedCamper = await camperService.inviteWaitlistedCamper(
+      req.params.waitlistedCamperId,
+    );
+    res.status(200).json(updatedWaitlistedCamper);
+  } catch (error: unknown) {
+    res.status(500).json({
+      error: getErrorMessage(error),
+      id: req.params.waitlistedCamperId,
+    });
+  }
+});
 
 /* Update the camper with the specified camperId */
 camperRouter.patch(

--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -129,6 +129,7 @@ camperRouter.patch(
           campSession: req.body.campSession,
           formResponses: req.body.formResponses,
           hasPaid: req.body.hasPaid,
+          optionalClauses: req.body.optionalClauses,
         },
       );
       res.status(200).json(updatedCampers);

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -5,6 +5,8 @@ import {
   CreateCampSessionsDTO,
   CreateFormQuestionsDTO,
   UpdateCampSessionDTO,
+  UpdateCampDTO,
+  CampDTO,
 } from "../../../types";
 import MgCampSession from "../../../models/campSession.model";
 import MgCamp from "../../../models/camp.model";
@@ -19,6 +21,7 @@ const fileStorageService: IFileStorageService = new FileStorageService(
 
 const testCamps: CreateCampDTO[] = [
   {
+    active: false,
     ageLower: 15,
     ageUpper: 30,
     name: "test camp",
@@ -27,8 +30,16 @@ const testCamps: CreateCampDTO[] = [
     fee: 25,
     campSessions: [],
     formQuestions: [],
+    campCoordinators: ["61fb3d34272ea0002ad6a24d"],
+    campCounsellors: ["61fb3d34272ea0002ad6a24d"],
+    earlyDropoff: "12:30",
+    latePickup: "2:30",
+    startTime: "6:49",
+    endTime: "16:09",
+    volunteers: ["jason"],
   },
   {
+    active: true,
     ageLower: 30,
     ageUpper: 50,
     name: "test camp2",
@@ -37,6 +48,13 @@ const testCamps: CreateCampDTO[] = [
     fee: 24,
     campSessions: [],
     formQuestions: [],
+    campCoordinators: ["61fb3d34272ea0002ad6a24d"],
+    campCounsellors: ["61fb3d34272ea0002ad6a24d"],
+    earlyDropoff: "12:30",
+    latePickup: "2:30",
+    startTime: "6:49",
+    endTime: "16:09",
+    volunteers: ["jason"],
   },
 ];
 
@@ -68,23 +86,28 @@ describe("mongo campService", (): void => {
 
   it("registerCamp", async () => {
     const testCamp: CreateCampDTO = {
+      active: false,
       ageLower: 15,
       ageUpper: 30,
+      campCoordinators: ["61fb3d34272ea0002ad6a24d"],
+      campCounsellors: ["61fb3d34272ea0002ad6a24d"],
+      earlyDropoff: "12:30",
+      latePickup: "2:30",
       name: "test camp",
       description: "description",
       location: "canada",
       fee: 25,
       formQuestions: [],
       campSessions: [],
+      startTime: "6:49",
+      endTime: "16:09",
+      volunteers: ["jason"],
     };
 
     const testCampSessions: CreateCampSessionsDTO = [
       {
         capacity: 20,
         dates: ["Sun Mar 13 2022 20:01:14 GMT-0600 (Mountain Daylight Time)"],
-        startTime: "6:49",
-        endTime: "16:09",
-        active: true,
       },
       {
         capacity: 20,
@@ -95,18 +118,12 @@ describe("mongo campService", (): void => {
           new Date(2023, 1, 5),
           new Date(2023, 1, 6),
         ].map((date) => date.toString()),
-        startTime: "6:49",
-        endTime: "16:09",
-        active: false,
       },
       {
         capacity: 20,
         dates: [new Date(2023, 1, 7), new Date(2023, 1, 8)].map((date) =>
           date.toString(),
         ),
-        startTime: "6:49",
-        endTime: "16:09",
-        active: false,
       },
     ];
 
@@ -123,12 +140,24 @@ describe("mongo campService", (): void => {
     // Step 1: Create camp with basic details
     const res = await campService.createCamp(testCamp);
     const camp = await MgCamp.findById(res.id).exec();
+    expect(camp?.active).toEqual(testCamp.active);
     expect(camp?.ageLower).toEqual(testCamp.ageLower);
     expect(camp?.ageUpper).toEqual(testCamp.ageUpper);
     expect(camp?.name).toEqual(testCamp.name);
     expect(camp?.description).toEqual(testCamp.description);
     expect(camp?.location).toEqual(testCamp.location);
     expect(camp?.fee).toEqual(testCamp.fee);
+    expect(camp?.startTime).toEqual(testCamp.startTime);
+    expect(camp?.endTime).toEqual(testCamp.endTime);
+    expect(camp?.active).toEqual(testCamp.active);
+    expect(
+      camp?.campCoordinators.map((coordinator) => coordinator.toString()),
+    ).toEqual(testCamp.campCoordinators);
+    expect(
+      camp?.campCounsellors.map((counsellor) => counsellor.toString()),
+    ).toEqual(testCamp.campCounsellors);
+    expect(camp?.earlyDropoff).toEqual(testCamp.earlyDropoff);
+    expect(camp?.latePickup).toEqual(testCamp.latePickup);
 
     // Step 2: Add Camp Sessions
     const campSessions = await campService.createCampSessions(
@@ -142,9 +171,6 @@ describe("mongo campService", (): void => {
       expect(campSession.dates.map((date) => new Date(date))).toEqual(
         testCampSessions[i].dates.map((date) => new Date(date)),
       );
-      expect(campSession.startTime).toEqual(testCampSessions[i].startTime);
-      expect(campSession.endTime).toEqual(testCampSessions[i].endTime);
-      expect(campSession.active).toEqual(testCampSessions[i].active);
       expect(campSession.capacity).toEqual(testCampSessions[i].capacity);
       expect(campSession.campers).toHaveLength(0);
       expect(campSession.waitlist).toHaveLength(0);
@@ -153,25 +179,30 @@ describe("mongo campService", (): void => {
     // TODO: Step 3: Add form questions :eyes
   });
 
-  it("updateCamp", async () => {
+  it("updateCampSession", async () => {
     const testCamp: CreateCampDTO = {
+      active: false,
       ageLower: 15,
       ageUpper: 30,
+      campCoordinators: ["61fb3d34272ea0002ad6a24d"],
+      campCounsellors: ["61fb3d34272ea0002ad6a24d"],
+      earlyDropoff: "12:30",
+      latePickup: "2:30",
       name: "test camp",
       description: "description",
       location: "canada",
       fee: 25,
       formQuestions: [],
       campSessions: [],
+      startTime: "6:49",
+      endTime: "16:09",
+      volunteers: ["jason"],
     };
 
     const testCampSessions: CreateCampSessionsDTO = [
       {
         capacity: 20,
         dates: ["Sun Mar 13 2022 20:01:14 GMT-0600 (Mountain Daylight Time)"],
-        startTime: "6:49",
-        endTime: "16:09",
-        active: true,
       },
     ];
 
@@ -184,9 +215,6 @@ describe("mongo campService", (): void => {
         new Date(2023, 1, 5),
         new Date(2023, 1, 6),
       ].map((date) => date.toString()),
-      startTime: "6:49",
-      endTime: "16:09",
-      active: false,
     };
 
     // Create camp with basic details
@@ -210,9 +238,6 @@ describe("mongo campService", (): void => {
     expect(campSession?.dates.map((date) => new Date(date))).toEqual(
       updatedTestCampSession.dates.map((date) => new Date(date)),
     );
-    expect(campSession?.startTime).toEqual(updatedTestCampSession.startTime);
-    expect(campSession?.endTime).toEqual(updatedTestCampSession.endTime);
-    expect(campSession?.active).toEqual(updatedTestCampSession.active);
     expect(campSession?.capacity).toEqual(updatedTestCampSession.capacity);
     expect(campSession?.campers).toHaveLength(0);
     expect(campSession?.waitlist).toHaveLength(0);
@@ -236,11 +261,6 @@ describe("mongo campService", (): void => {
         expect(campSession.dates.map((date) => new Date(date))).toEqual(
           testCamp.campSessions[i].dates.map((date) => new Date(date)),
         );
-        expect(campSession.startTime).toEqual(
-          testCamp.campSessions[i].startTime,
-        );
-        expect(campSession.endTime).toEqual(testCamp.campSessions[i].endTime);
-        expect(campSession.active).toEqual(testCamp.campSessions[i].active);
         expect(campSession.capacity).toEqual(testCamp.campSessions[i].capacity);
         expect(campSession.campers).toHaveLength(0);
         expect(campSession.waitlist).toHaveLength(0);
@@ -277,6 +297,77 @@ describe("mongo campService", (): void => {
       expect(res.description).toEqual(testCamp.description);
       expect(res.location).toEqual(testCamp.location);
       expect(res.fee).toEqual(testCamp.fee);
+      expect(res.startTime).toEqual(testCamp.startTime);
+      expect(res.endTime).toEqual(testCamp.endTime);
+      expect(res.active).toEqual(testCamp.active);
+      expect(res.campCoordinators).toEqual(testCamp.campCoordinators);
+      expect(res.campCounsellors).toEqual(testCamp.campCounsellors);
+      expect(res.earlyDropoff).toEqual(testCamp.earlyDropoff);
+      expect(res.latePickup).toEqual(testCamp.latePickup);
     }
+  });
+
+  it("updateCamp", async () => {
+    const testCamp: CreateCampDTO = {
+      active: false,
+      ageLower: 15,
+      ageUpper: 30,
+      campCoordinators: ["61fb3d34272ea0002ad6a24d"],
+      campCounsellors: ["61fb3d34272ea0002ad6a24d"],
+      earlyDropoff: "12:30",
+      latePickup: "2:30",
+      name: "test camp",
+      description: "description",
+      location: "canada",
+      fee: 25,
+      formQuestions: [],
+      campSessions: [],
+      startTime: "6:49",
+      endTime: "16:09",
+      volunteers: ["jason"],
+    };
+
+    const updatedTestCamp: UpdateCampDTO = {
+      active: true,
+      ageLower: 15,
+      ageUpper: 30,
+      campCoordinators: [],
+      campCounsellors: [],
+      earlyDropoff: "2:30",
+      latePickup: "8:30",
+      name: "ab",
+      description: "ba",
+      location: "ca",
+      fee: 50,
+      startTime: "8:49",
+      endTime: "12:09",
+      volunteers: ["jason", "elon"],
+    };
+
+    // create camp
+    const res = await campService.createCamp(testCamp);
+
+    await campService.updateCampById(res.id, updatedTestCamp);
+
+    // TODO (jason): would be nice to have a generic "validateCamp" function instead of hardcoding fields
+    const camp = await MgCamp.findById(res.id);
+    expect(camp?.active).toEqual(updatedTestCamp.active);
+    expect(camp?.ageLower).toEqual(updatedTestCamp.ageLower);
+    expect(camp?.ageUpper).toEqual(updatedTestCamp.ageUpper);
+    expect(camp?.name).toEqual(updatedTestCamp.name);
+    expect(camp?.description).toEqual(updatedTestCamp.description);
+    expect(camp?.location).toEqual(updatedTestCamp.location);
+    expect(camp?.fee).toEqual(updatedTestCamp.fee);
+    expect(camp?.startTime).toEqual(updatedTestCamp.startTime);
+    expect(camp?.endTime).toEqual(updatedTestCamp.endTime);
+    expect(camp?.active).toEqual(updatedTestCamp.active);
+    expect(
+      camp?.campCoordinators.map((coordinator) => coordinator.toString()),
+    ).toEqual(updatedTestCamp.campCoordinators);
+    expect(
+      camp?.campCounsellors.map((counsellor) => counsellor.toString()),
+    ).toEqual(updatedTestCamp.campCounsellors);
+    expect(camp?.earlyDropoff).toEqual(updatedTestCamp.earlyDropoff);
+    expect(camp?.latePickup).toEqual(updatedTestCamp.latePickup);
   });
 });

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -370,4 +370,67 @@ describe("mongo campService", (): void => {
     expect(camp?.earlyDropoff).toEqual(updatedTestCamp.earlyDropoff);
     expect(camp?.latePickup).toEqual(updatedTestCamp.latePickup);
   });
+
+  it("deleteCamp", async () => {
+    // add camp
+    const res = await campService.createCamp({
+      active: true,
+      ageLower: 5,
+      ageUpper: 12,
+      name: "Test Camp",
+      description: "description",
+      location: "Canada",
+      fee: 7,
+      campCoordinators: [],
+      campCounsellors: [],
+      earlyDropoff: "14:00",
+      latePickup: "19:00",
+      startTime: "15:00",
+      endTime: "18:00",
+      formQuestions: [
+        {
+          type: "Text",
+          question: "how is it going",
+          required: true,
+          description: "asdfasdf",
+        },
+        {
+          type: "Text",
+          question: "Hi",
+          required: true,
+          description: "Description",
+        },
+      ],
+      campSessions: [
+        {
+          capacity: 12,
+          dates: ["December 17, 1995 03:24:00"],
+        },
+      ],
+      volunteers: [],
+    });
+
+    const camp = await MgCamp.findById(res.id).exec();
+    expect(camp).toBeInstanceOf(MgCamp); // make sure not null
+    expect(res.campSessions).toHaveLength(1);
+    expect(res.formQuestions).toHaveLength(2);
+
+    // delete camp
+    await campService.deleteCamp(res.id);
+
+    const deletedCamp = await MgCamp.findById(res.id).exec();
+    const deletedCampSession = await MgCampSession.findById(
+      res.campSessions[0],
+    );
+    const deletedFirstFormQuestion = await MgFormQuestion.findById(
+      res.formQuestions[0],
+    );
+    const deletedSecondFormQuestion = await MgFormQuestion.findById(
+      res.formQuestions[1],
+    );
+    expect(deletedCamp).toBeNull(); // make sure deleted
+    expect(deletedCampSession).toBeNull();
+    expect(deletedFirstFormQuestion).toBeNull();
+    expect(deletedSecondFormQuestion).toBeNull();
+  });
 });

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -66,24 +66,33 @@ class CampService implements ICampService {
             id: campSession.id,
             capacity: campSession.capacity,
             dates: campSession.dates.map((date) => date.toString()),
-            startTime: campSession.startTime,
-            endTime: campSession.endTime,
             registrations: campSession.campers.length,
             waitlist: campSession.waitlist.length,
-            active: campSession.active,
           }),
         );
 
         return {
           id: camp.id,
+          active: camp.active,
           ageLower: camp.ageLower,
           ageUpper: camp.ageUpper,
+          campCoordinators: camp.campCoordinators.map((coordinator) =>
+            coordinator.toString(),
+          ),
+          campCounsellors: camp.campCounsellors.map((counsellor) =>
+            counsellor.toString(),
+          ),
           name: camp.name,
           description: camp.description,
+          earlyDropoff: camp.earlyDropoff,
+          latePickup: camp.latePickup,
           location: camp.location,
+          startTime: camp.startTime,
+          endTime: camp.endTime,
           fee: camp.fee,
           formQuestions,
           campSessions,
+          volunteers: camp.volunteers,
         };
       });
     } catch (error: unknown) {
@@ -99,11 +108,19 @@ class CampService implements ICampService {
       oldCamp = await MgCamp.findByIdAndUpdate(campId, {
         $set: {
           name: camp.name,
+          active: camp.active,
           ageLower: camp.ageLower,
           ageUpper: camp.ageUpper,
+          campCoordinators: camp.campCoordinators,
+          campCounsellors: camp.campCounsellors,
           description: camp.description,
+          earlyDropoff: camp.earlyDropoff,
+          latePickup: camp.latePickup,
           location: camp.location,
+          startTime: camp.startTime,
+          endTime: camp.endTime,
           fee: camp.fee,
+          volunteers: camp.volunteers,
         },
       });
       if (!oldCamp) {
@@ -116,16 +133,28 @@ class CampService implements ICampService {
 
     return {
       id: campId,
+      active: camp.active,
       ageLower: camp.ageLower,
       ageUpper: camp.ageUpper,
+      campCoordinators: camp.campCoordinators.map((coordinator) =>
+        coordinator.toString(),
+      ),
+      campCounsellors: camp.campCounsellors.map((counsellor) =>
+        counsellor.toString(),
+      ),
       campSessions: oldCamp.campSessions.map((session) => session.toString()),
       name: camp.name,
       description: camp.description,
+      earlyDropoff: camp.earlyDropoff,
+      latePickup: camp.latePickup,
       location: camp.location,
+      startTime: camp.startTime,
+      endTime: camp.endTime,
       fee: camp.fee,
       formQuestions: oldCamp.formQuestions.map((formQuestion) =>
         formQuestion.toString(),
       ),
+      volunteers: camp.volunteers,
     };
   }
 
@@ -141,9 +170,6 @@ class CampService implements ICampService {
         capacity: campSession.capacity,
         waitlist: [],
         dates: campSession.dates.sort(),
-        startTime: campSession.startTime,
-        endTime: campSession.endTime,
-        active: campSession.active,
       });
     });
 
@@ -190,9 +216,6 @@ class CampService implements ICampService {
           capacity: session.capacity,
           waitlist: [],
           dates: session.dates.map((date) => date.toString()),
-          startTime: session.startTime,
-          endTime: session.endTime,
-          active: session.active,
         },
     );
   }
@@ -221,9 +244,6 @@ class CampService implements ICampService {
         {
           capacity: campSession.capacity,
           dates: campSession.dates.sort(),
-          startTime: campSession.startTime,
-          endTime: campSession.endTime,
-          active: campSession.active,
         },
         { runValidators: true, new: true },
       );
@@ -241,9 +261,6 @@ class CampService implements ICampService {
         capacity: newCampSession.capacity,
         waitlist: newCampSession.waitlist.map((camper) => camper.toString()),
         dates: newCampSession.dates.map((date) => date.toString()),
-        startTime: newCampSession.startTime,
-        endTime: newCampSession.endTime,
-        active: newCampSession.active,
       };
     } catch (error: unknown) {
       Logger.error(
@@ -374,12 +391,20 @@ class CampService implements ICampService {
       }
       newCamp = new MgCamp({
         name: camp.name,
+        active: camp.active,
         ageLower: camp.ageLower,
         ageUpper: camp.ageUpper,
+        campCoordinators: camp.campCoordinators,
+        campCounsellors: camp.campCounsellors,
         description: camp.description,
+        earlyDropoff: camp.earlyDropoff,
+        endTime: camp.endTime,
+        latePickup: camp.latePickup,
         location: camp.location,
+        startTime: camp.startTime,
         fee: camp.fee,
         formQuestions: [],
+        volunteers: camp.volunteers,
         ...(camp.filePath && { fileName }),
       });
 
@@ -406,10 +431,7 @@ class CampService implements ICampService {
               camp: newCamp,
               campers: [],
               waitlist: [],
-              startTime: campSession.startTime,
-              endTime: campSession.endTime,
               dates: campSession.dates,
-              active: campSession.active,
             });
             newCamp.campSessions[i] = session._id;
           }),
@@ -450,17 +472,29 @@ class CampService implements ICampService {
 
     return {
       id: newCamp.id,
+      active: newCamp.active,
       ageLower: newCamp.ageLower,
       ageUpper: newCamp.ageUpper,
       campSessions: newCamp.campSessions.map((session) => session.toString()),
+      campCoordinators: newCamp.campCoordinators.map((coordinator) =>
+        coordinator.toString(),
+      ),
+      campCounsellors: newCamp.campCounsellors.map((counsellor) =>
+        counsellor.toString(),
+      ),
       name: newCamp.name,
       description: newCamp.description,
+      earlyDropoff: newCamp.earlyDropoff,
+      latePickup: newCamp.latePickup,
       location: newCamp.location,
       fee: newCamp.fee,
       formQuestions: newCamp.formQuestions.map((formQuestion) =>
         formQuestion.toString(),
       ),
       fileName: newCamp.fileName,
+      startTime: newCamp.startTime,
+      endTime: newCamp.endTime,
+      volunteers: newCamp.volunteers,
     };
   }
 
@@ -474,9 +508,6 @@ class CampService implements ICampService {
         {
           capacity: campSession.capacity,
           dates: campSession.dates,
-          startTime: campSession.startTime,
-          endTime: campSession.endTime,
-          active: campSession.active,
         },
         { runValidators: true, new: true },
       );
@@ -494,9 +525,6 @@ class CampService implements ICampService {
         capacity: newCampSession.capacity,
         waitlist: newCampSession.waitlist.map((camper) => camper.toString()),
         dates: newCampSession.dates.map((date) => date.toString()),
-        startTime: newCampSession.startTime,
-        endTime: newCampSession.endTime,
-        active: newCampSession.active,
       };
     } catch (error: unknown) {
       Logger.error(

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -158,6 +158,72 @@ class CampService implements ICampService {
     };
   }
 
+  async deleteCamp(campId: string): Promise<void> {
+    let camp: Camp | null;
+
+    try {
+      camp = await MgCamp.findById(campId);
+      if (!camp) {
+        throw new Error(`Camp with camp ID ${campId} not found.`);
+      }
+
+      // delete the camp's file, if it exists
+      if (camp.fileName) {
+        await this.storageService.deleteFile(camp.fileName);
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to delete camp. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    try {
+      try {
+        // delete the form questions and camp sessions
+        if (camp.formQuestions.length) {
+          await Promise.all(
+            camp.formQuestions.map(async (formQuestionId) => {
+              try {
+                await MgFormQuestion.findByIdAndDelete(formQuestionId);
+              } catch (deleteFormQuestionErr: unknown) {
+                // log error but don't throw
+                Logger.error(
+                  `Issues with form question deletion. Reason = ${getErrorMessage(
+                    deleteFormQuestionErr,
+                  )}`,
+                );
+              }
+            }),
+          );
+        }
+        if (camp.campSessions.length) {
+          await Promise.all(
+            camp.campSessions.map(async (campSessionId) => {
+              try {
+                await this.deleteCampSessionById(
+                  campId,
+                  campSessionId.toString(),
+                );
+              } catch (deleteCampSessionErr: unknown) {
+                Logger.error(
+                  `Issues with delete camp session deletion. Reason = ${getErrorMessage(
+                    deleteCampSessionErr,
+                  )}`,
+                );
+              }
+            }),
+          );
+        }
+      } catch (deleteError: unknown) {
+        // don't do anything
+      }
+
+      await MgCamp.findByIdAndDelete(campId); // delete camp itself
+    } catch (error: unknown) {
+      Logger.error(`Failed to delete camp. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
   async createCampSessions(
     campId: string,
     campSessions: CreateCampSessionsDTO,
@@ -274,6 +340,7 @@ class CampService implements ICampService {
     campId: string,
     campSessionId: string,
   ): Promise<void> {
+    let campSession: CampSession | null;
     try {
       const oldCamp: Camp | null = await MgCamp.findById(campId);
       if (!oldCamp) {
@@ -287,20 +354,44 @@ class CampService implements ICampService {
           `CampSession with campSessionId ${campSessionId} not found for Camp with id ${campId}.`,
         );
       }
-      const campSession = await MgCampSession.findByIdAndRemove(campSessionId);
+      campSession = await MgCampSession.findByIdAndRemove(campSessionId);
       if (!campSession) {
         throw new Error(
           `CampSession' with campSessionID ${campSessionId} not found.`,
         );
       }
+
       await MgCamp.findByIdAndUpdate(campId, {
         $pullAll: { campSessions: [campSession.id] },
       });
     } catch (error: unknown) {
       Logger.error(
-        `Failed to delete CampSession. Reason = ${getErrorMessage(error)}`,
+        `Failed to delete CampSession ${campSessionId} properly. Reason = ${getErrorMessage(
+          error,
+        )}`,
       );
       throw error;
+    }
+
+    // delete all the campers belonging to the camp session
+    const existingCampers = [...campSession.campers];
+    let numberOfCampersDeleted = 0;
+
+    try {
+      Promise.all(
+        existingCampers.map(async (camperId) => {
+          await MgCamper.findByIdAndDelete(camperId);
+          numberOfCampersDeleted += 1;
+        }),
+      );
+    } catch (error: unknown) {
+      // log but don't throw error
+      const errorMessage = [
+        `Failed to delete all campers belonging to camp session ${campSessionId}. Campers not deleted, although CampSession has been deleted`,
+        "Campers not yet deleted:",
+        existingCampers.slice(numberOfCampersDeleted),
+      ];
+      Logger.error(errorMessage.join(" "));
     }
   }
 

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -342,14 +342,15 @@ class CampService implements ICampService {
             allergies: camper.allergies,
             hasCamera: camper.hasCamera,
             hasLaptop: camper.hasLaptop,
-            earlyDropoff: camper.earlyDropoff,
-            latePickup: camper.latePickup,
+            earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
+            latePickup: camper.latePickup.map((date) => date.toString()),
             specialNeeds: camper.specialNeeds,
             contacts: camper.contacts,
             formResponses: formResponseObject,
-            registrationDate: camper.registrationDate,
+            registrationDate: camper.registrationDate.toString(),
             hasPaid: camper.hasPaid,
             chargeId: camper.chargeId,
+            optionalClauses: camper.optionalClauses,
           };
         }),
       );

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -124,15 +124,16 @@ class CamperService implements ICamperService {
         allergies: newCamper.allergies,
         hasCamera: newCamper.hasCamera,
         hasLaptop: newCamper.hasLaptop,
-        earlyDropoff: newCamper.earlyDropoff,
-        latePickup: newCamper.latePickup,
+        earlyDropoff: newCamper.earlyDropoff.map((date) => date.toString()),
+        latePickup: newCamper.latePickup.map((date) => date.toString()),
         specialNeeds: newCamper.specialNeeds,
         contacts: newCamper.contacts,
-        registrationDate: newCamper.registrationDate,
+        registrationDate: newCamper.registrationDate.toString(),
         hasPaid: newCamper.hasPaid,
         chargeId: newCamper.chargeId,
         formResponses: newCamper.formResponses,
         charges: newCamper.charges,
+        optionalClauses: newCamper.optionalClauses,
       };
     });
     return newCamperDTOs;
@@ -153,15 +154,16 @@ class CamperService implements ICamperService {
           allergies: camper.allergies,
           hasCamera: camper.hasCamera,
           hasLaptop: camper.hasLaptop,
-          earlyDropoff: camper.earlyDropoff,
-          latePickup: camper.latePickup,
+          earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
+          latePickup: camper.latePickup.map((date) => date.toString()),
           specialNeeds: camper.specialNeeds,
           contacts: camper.contacts,
-          registrationDate: camper.registrationDate,
+          registrationDate: camper.registrationDate.toString(),
           hasPaid: camper.hasPaid,
           chargeId: camper.chargeId,
           formResponses: camper.formResponses,
           charges: camper.charges,
+          optionalClauses: camper.optionalClauses,
         };
       });
     } catch (error: unknown) {
@@ -210,15 +212,16 @@ class CamperService implements ICamperService {
           allergies: camper.allergies,
           hasCamera: camper.hasCamera,
           hasLaptop: camper.hasLaptop,
-          earlyDropoff: camper.earlyDropoff,
-          latePickup: camper.latePickup,
+          earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
+          latePickup: camper.latePickup.map((date) => date.toString()),
           specialNeeds: camper.specialNeeds,
           contacts: camper.contacts,
-          registrationDate: camper.registrationDate,
+          registrationDate: camper.registrationDate.toString(),
           hasPaid: camper.hasPaid,
           chargeId: camper.chargeId,
           formResponses: camper.formResponses,
           charges: camper.charges,
+          optionalClauses: camper.optionalClauses,
         };
       });
 
@@ -263,15 +266,16 @@ class CamperService implements ICamperService {
           allergies: camper.allergies,
           hasCamera: camper.hasCamera,
           hasLaptop: camper.hasLaptop,
-          earlyDropoff: camper.earlyDropoff,
-          latePickup: camper.latePickup,
+          earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
+          latePickup: camper.latePickup.map((date) => date.toString()),
           specialNeeds: camper.specialNeeds,
           contacts: camper.contacts,
           formResponses: camper.formResponses,
-          registrationDate: camper.registrationDate,
+          registrationDate: camper.registrationDate.toString(),
           hasPaid: camper.hasPaid,
           chargeId: camper.chargeId,
           charges: camper.charges,
+          optionalClauses: camper.optionalClauses,
         };
       });
 
@@ -535,15 +539,16 @@ class CamperService implements ICamperService {
         allergies: updatedCamper.allergies,
         hasCamera: updatedCamper.hasCamera,
         hasLaptop: updatedCamper.hasLaptop,
-        earlyDropoff: updatedCamper.earlyDropoff,
-        latePickup: updatedCamper.latePickup,
+        earlyDropoff: updatedCamper.earlyDropoff.map((date) => date.toString()),
+        latePickup: updatedCamper.latePickup.map((date) => date.toString()),
         specialNeeds: updatedCamper.specialNeeds,
         contacts: updatedCamper.contacts,
         formResponses: updatedCamper.formResponses,
-        registrationDate: updatedCamper.registrationDate,
+        registrationDate: updatedCamper.registrationDate.toString(),
         hasPaid: updatedCamper.hasPaid,
         chargeId: updatedCamper.chargeId,
         charges: updatedCamper.charges,
+        optionalClauses: updatedCamper.optionalClauses,
       };
     });
 

--- a/backend/typescript/services/implementations/emailService.ts
+++ b/backend/typescript/services/implementations/emailService.ts
@@ -159,7 +159,7 @@ class EmailService implements IEmailService {
   ): Promise<void> {
     const link = ""; // TODO: fix link
     await this.sendEmail(
-      ADMIN_EMAIL,
+      waitlistedCamper.contactEmail,
       "Focus on Nature Camp Registration - Invitation to Register",
       `Hi ${waitlistedCamper.contactName},<br><br>
       A spot opened up in ${camp.name} for the following session dates: 

--- a/backend/typescript/services/implementations/emailService.ts
+++ b/backend/typescript/services/implementations/emailService.ts
@@ -116,6 +116,41 @@ class EmailService implements IEmailService {
     );
   }
 
+  async sendParentMovedConfirmationEmail(
+    campers: Camper[],
+    camp: Camp,
+    oldCampSession: CampSession,
+    newCampSession: CampSession,
+  ): Promise<void> {
+    let camperNames = "";
+    const placeholder = campers.length > 1 ? "have" : "has";
+    const contact = campers[0].contacts[0];
+    for (let i = 0; i < campers.length; i += 1) {
+      camperNames += `${campers[i].firstName} ${campers[i].lastName}`;
+      if (i === campers.length - 1) {
+        break;
+      } else if (i === campers.length - 2) {
+        camperNames += " and ";
+      } else {
+        camperNames += ", ";
+      }
+    }
+
+    await this.sendEmail(
+      contact.email,
+      "Focus on Nature Camp Session Change - Confirmation",
+      `Hi ${contact.firstName} ${contact.lastName},<br><br>
+      This following email is to notify you that ${camperNames} ${placeholder} been successfully 
+      moved from ${camp.name} happening on
+      ${sessionDatesToString(oldCampSession.dates)} to ${camp.name} happening on
+      ${sessionDatesToString(newCampSession.dates)}.<br><br>
+      If you have further questions or concerns, please do not hesitate to contact camps@focusonnature.ca.<br><br>
+      Thanks,<br><br>
+      Focus on Nature
+      `,
+    );
+  }
+
   async sendParentWaitlistConfirmationEmail(
     camp: Camp,
     campSession: CampSession,

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -22,6 +22,8 @@ interface ICampService {
 
   updateCampById(campId: string, camp: UpdateCampDTO): Promise<CampDTO>;
 
+  deleteCamp(campId: string): Promise<void>;
+
   deleteCampSessionById(campId: string, campSessionId: string): Promise<void>;
 
   createCampSessions(

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -80,6 +80,13 @@ interface ICamperService {
    */
   deleteCampersById(camperIds: Array<string>): Promise<void>;
   /**
+   * Sends email inviting waitlisted camper to register and updates their status
+   * @param waitlistedCamperId waitlisted camper's Id
+   * @throws Error if waitlisted camper's status update fails
+   */
+  inviteWaitlistedCamper(waitlistedCamperId: string): Promise<any>;
+
+  /**
    * Delete waitlisted camper associated with the ID
    * @param waitlistedCamperId waitlisted camper's Id
    * @throws Error if waitlisted camper deletion fails

--- a/backend/typescript/services/interfaces/emailService.ts
+++ b/backend/typescript/services/interfaces/emailService.ts
@@ -21,6 +21,17 @@ interface IEmailService {
   sendParentCancellationConfirmationEmail(campers: Camper[]): Promise<void>;
 
   /**
+   * Send a confirmation email that a camper has been successfully between camp sessions.
+   * @throws Error if email was not sent successfully
+   */
+  sendParentMovedConfirmationEmail(
+    campers: Camper[],
+    camp: Camp,
+    oldCampSession: CampSession,
+    newCampSession: CampSession,
+  ): Promise<void>;
+
+  /**
    * Send camp waitlist confirmation email.
    * @throws Error if email was not sent successfully
    */

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -78,6 +78,7 @@ export type WaitlistedCamperDTO = {
   contactEmail: string;
   contactNumber: string;
   campSession: string;
+  status: string;
 };
 
 export type CreateUserDTO = Omit<UserDTO, "id">;
@@ -181,3 +182,8 @@ export type WaiverDTO = {
 export type FormTemplateDTO = {
   formQuestions: [FormQuestionDTO];
 };
+
+export type WaitlistedCamperStatus =
+  | "NotRegistered"
+  | "RegistrationFormSent"
+  | "Registered";

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -38,8 +38,8 @@ export type CamperDTO = {
   allergies: string;
   hasCamera: boolean;
   hasLaptop: boolean;
-  earlyDropoff: string;
-  latePickup: string;
+  earlyDropoff: string[];
+  latePickup: string[];
   specialNeeds: string;
   contacts: {
     firstName: string;
@@ -47,7 +47,7 @@ export type CamperDTO = {
     email: string;
     phoneNumber: string;
   }[];
-  registrationDate: Date;
+  registrationDate: string;
   hasPaid: boolean;
   formResponses: Map<string, string>;
   chargeId: string;
@@ -56,6 +56,12 @@ export type CamperDTO = {
     earlyDropoff: number;
     latePickup: number;
   };
+  optionalClauses: [
+    {
+      clause: string;
+      agreed: boolean;
+    },
+  ];
 };
 
 export type CamperCSVInfoDTO = Omit<

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -94,22 +94,27 @@ export type CampSessionDTO = {
   campers: string[];
   waitlist: string[];
   dates: string[];
-  startTime: string;
-  endTime: string;
-  active: boolean;
 };
 
 export type CampDTO = {
   id: string;
+  active: boolean;
   ageLower: number;
   ageUpper: number;
+  campCoordinators: string[];
+  campCounsellors: string[];
   name: string;
   description: string;
+  earlyDropoff: string;
+  endTime: string;
+  latePickup: string;
   location: string;
+  startTime: string;
   fee: number;
   formQuestions: string[];
   campSessions: string[];
   fileName?: string;
+  volunteers: string[];
 };
 
 export type GetCampDTO = Omit<CampDTO, "campSessions" | "formQuestions"> & {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-S22-1a3e651ab8544192bf0fdcbba04f6d03?p=36046d9832f345aa824e498808614fcc)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added delete camp endpoint which takes in a camp id and deletes the camp's form questions, file, and camp sessions
* modified camp session deletion to also delete the associated campers


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a camp with an associated file, form questions, and camp sessions each with campers
2. Ensure deletion will delete all these fields from the database
3. If a camp session deletion fails, the program shouldn't throw an error in the middle of camp sessions deletions, but rather at the end


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensure error handling is correct for camp session deletion


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
