### PR TITLE
feat: add delete camp endpoint

### DIFF
--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -168,4 +168,14 @@ campRouter.get("/csv/:id", async (req, res) => {
   }
 });
 
+/* Delete a camp */
+campRouter.delete("/:id", async (req, res) => {
+  try {
+    await campService.deleteCamp(req.params.id);
+    res.status(204).send();
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 export default campRouter;

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -370,4 +370,67 @@ describe("mongo campService", (): void => {
     expect(camp?.earlyDropoff).toEqual(updatedTestCamp.earlyDropoff);
     expect(camp?.latePickup).toEqual(updatedTestCamp.latePickup);
   });
+
+  it("deleteCamp", async () => {
+    // add camp
+    const res = await campService.createCamp({
+      active: true,
+      ageLower: 5,
+      ageUpper: 12,
+      name: "Test Camp",
+      description: "description",
+      location: "Canada",
+      fee: 7,
+      campCoordinators: [],
+      campCounsellors: [],
+      earlyDropoff: "14:00",
+      latePickup: "19:00",
+      startTime: "15:00",
+      endTime: "18:00",
+      formQuestions: [
+        {
+          type: "Text",
+          question: "how is it going",
+          required: true,
+          description: "asdfasdf",
+        },
+        {
+          type: "Text",
+          question: "Hi",
+          required: true,
+          description: "Description",
+        },
+      ],
+      campSessions: [
+        {
+          capacity: 12,
+          dates: ["December 17, 1995 03:24:00"],
+        },
+      ],
+      volunteers: [],
+    });
+
+    const camp = await MgCamp.findById(res.id).exec();
+    expect(camp).toBeInstanceOf(MgCamp); // make sure not null
+    expect(res.campSessions).toHaveLength(1);
+    expect(res.formQuestions).toHaveLength(2);
+
+    // delete camp
+    await campService.deleteCamp(res.id);
+
+    const deletedCamp = await MgCamp.findById(res.id).exec();
+    const deletedCampSession = await MgCampSession.findById(
+      res.campSessions[0],
+    );
+    const deletedFirstFormQuestion = await MgFormQuestion.findById(
+      res.formQuestions[0],
+    );
+    const deletedSecondFormQuestion = await MgFormQuestion.findById(
+      res.formQuestions[1],
+    );
+    expect(deletedCamp).toBeNull(); // make sure deleted
+    expect(deletedCampSession).toBeNull();
+    expect(deletedFirstFormQuestion).toBeNull();
+    expect(deletedSecondFormQuestion).toBeNull();
+  });
 });

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -158,6 +158,72 @@ class CampService implements ICampService {
     };
   }
 
+  async deleteCamp(campId: string): Promise<void> {
+    let camp: Camp | null;
+
+    try {
+      camp = await MgCamp.findById(campId);
+      if (!camp) {
+        throw new Error(`Camp with camp ID ${campId} not found.`);
+      }
+
+      // delete the camp's file, if it exists
+      if (camp.fileName) {
+        await this.storageService.deleteFile(camp.fileName);
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to delete camp. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    try {
+      try {
+        // delete the form questions and camp sessions
+        if (camp.formQuestions.length) {
+          await Promise.all(
+            camp.formQuestions.map(async (formQuestionId) => {
+              try {
+                await MgFormQuestion.findByIdAndDelete(formQuestionId);
+              } catch (deleteFormQuestionErr: unknown) {
+                // log error but don't throw
+                Logger.error(
+                  `Issues with form question deletion. Reason = ${getErrorMessage(
+                    deleteFormQuestionErr,
+                  )}`,
+                );
+              }
+            }),
+          );
+        }
+        if (camp.campSessions.length) {
+          await Promise.all(
+            camp.campSessions.map(async (campSessionId) => {
+              try {
+                await this.deleteCampSessionById(
+                  campId,
+                  campSessionId.toString(),
+                );
+              } catch (deleteCampSessionErr: unknown) {
+                Logger.error(
+                  `Issues with delete camp session deletion. Reason = ${getErrorMessage(
+                    deleteCampSessionErr,
+                  )}`,
+                );
+              }
+            }),
+          );
+        }
+      } catch (deleteError: unknown) {
+        // don't do anything
+      }
+
+      await MgCamp.findByIdAndDelete(campId); // delete camp itself
+    } catch (error: unknown) {
+      Logger.error(`Failed to delete camp. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
   async createCampSessions(
     campId: string,
     campSessions: CreateCampSessionsDTO,
@@ -274,6 +340,7 @@ class CampService implements ICampService {
     campId: string,
     campSessionId: string,
   ): Promise<void> {
+    let campSession: CampSession | null;
     try {
       const oldCamp: Camp | null = await MgCamp.findById(campId);
       if (!oldCamp) {
@@ -287,20 +354,44 @@ class CampService implements ICampService {
           `CampSession with campSessionId ${campSessionId} not found for Camp with id ${campId}.`,
         );
       }
-      const campSession = await MgCampSession.findByIdAndRemove(campSessionId);
+      campSession = await MgCampSession.findByIdAndRemove(campSessionId);
       if (!campSession) {
         throw new Error(
           `CampSession' with campSessionID ${campSessionId} not found.`,
         );
       }
+
       await MgCamp.findByIdAndUpdate(campId, {
         $pullAll: { campSessions: [campSession.id] },
       });
     } catch (error: unknown) {
       Logger.error(
-        `Failed to delete CampSession. Reason = ${getErrorMessage(error)}`,
+        `Failed to delete CampSession ${campSessionId} properly. Reason = ${getErrorMessage(
+          error,
+        )}`,
       );
       throw error;
+    }
+
+    // delete all the campers belonging to the camp session
+    const existingCampers = [...campSession.campers];
+    let numberOfCampersDeleted = 0;
+
+    try {
+      Promise.all(
+        existingCampers.map(async (camperId) => {
+          await MgCamper.findByIdAndDelete(camperId);
+          numberOfCampersDeleted += 1;
+        }),
+      );
+    } catch (error: unknown) {
+      // log but don't throw error
+      const errorMessage = [
+        `Failed to delete all campers belonging to camp session ${campSessionId}. Campers not deleted, although CampSession has been deleted`,
+        "Campers not yet deleted:",
+        existingCampers.slice(numberOfCampersDeleted),
+      ];
+      Logger.error(errorMessage.join(" "));
     }
   }
 

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -20,6 +20,8 @@ interface ICampService {
 
   createCamp(camp: CreateCampDTO): Promise<CampDTO>;
 
+  deleteCamp(campId: string): Promise<void>;
+
   updateCampById(campId: string, camp: UpdateCampDTO): Promise<CampDTO>;
 
   deleteCampSessionById(campId: string, campSessionId: string): Promise<void>;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-S22-1a3e651ab8544192bf0fdcbba04f6d03?p=36046d9832f345aa824e498808614fcc)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added delete camp endpoint which takes in a camp id and deletes the camp's form questions, file, and camp sessions
* modified camp session deletion to also delete the associated campers


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a camp with an associated file, form questions, and camp sessions each with campers
2. Ensure deletion will delete all these fields from the database
3. If a camp session deletion fails, the program shouldn't throw an error in the middle of camp sessions deletions, but rather at the end


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensure error handling is correct for camp session deletion


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
