### PR TITLE
feat: get camp by camp id

### DIFF
--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -27,6 +27,12 @@ const campService: ICampService = new CampService(fileStorageService);
 campRouter.get("/", async (req, res) => {
   try {
     const camps = await campService.getCamps();
+
+    if (req.params.id) {
+      await campService.getCampById(req.params.id);
+      res.status(204).send();
+    }
+
     res.status(200).json(camps);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -12,6 +12,7 @@ import {
   updateCampDtoValidator,
   updateCampSessionDtoValidator,
 } from "../middlewares/validators/campValidators";
+import camperRouter from "./camperRoutes";
 
 const upload = multer({ dest: "uploads/" });
 
@@ -34,6 +35,16 @@ campRouter.get("/", async (req, res) => {
     }
 
     res.status(200).json(camps);
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+campRouter.get("/:id", async (req, res) => {
+  try {
+    const camp = await campService.getCampById(req.params.id);
+
+    res.status(200).json(camp);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });
   }

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -28,12 +28,6 @@ const campService: ICampService = new CampService(fileStorageService);
 campRouter.get("/", async (req, res) => {
   try {
     const camps = await campService.getCamps();
-
-    if (req.params.id) {
-      await campService.getCampById(req.params.id);
-      res.status(204).send();
-    }
-
     res.status(200).json(camps);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -12,7 +12,6 @@ import {
   updateCampDtoValidator,
   updateCampSessionDtoValidator,
 } from "../middlewares/validators/campValidators";
-import camperRouter from "./camperRoutes";
 
 const upload = multer({ dest: "uploads/" });
 

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -101,6 +101,47 @@ class CampService implements ICampService {
     }
   }
 
+  async getCampById(campId: string): Promise<CampDTO> {
+    let camp: Camp | null;
+
+    try {
+      camp = await MgCamp.findById(campId);
+
+      if (!camp) {
+        throw new Error(`Camp' with campId ${campId} not found.`);
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to update camp. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    return{
+      id: campId,
+      active: camp.active,
+      ageLower: camp.ageLower,
+      ageUpper: camp.ageUpper,
+      campCoordinators: camp.campCoordinators.map((coordinator) =>
+        coordinator.toString(),
+      ),
+      campCounsellors: camp.campCounsellors.map((counsellor) =>
+        counsellor.toString(),
+      ),
+      campSessions: camp.campSessions.map((session) => session.toString()),
+      name: camp.name,
+      description: camp.description,
+      earlyDropoff: camp.earlyDropoff,
+      latePickup: camp.latePickup,
+      location: camp.location,
+      startTime: camp.startTime,
+      endTime: camp.endTime,
+      fee: camp.fee,
+      formQuestions: camp.formQuestions.map((formQuestion) =>
+        formQuestion.toString(),
+      ),
+      volunteers: camp.volunteers,
+    }
+  }
+
   async updateCampById(campId: string, camp: UpdateCampDTO): Promise<CampDTO> {
     let oldCamp: Camp | null;
 

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -115,7 +115,7 @@ class CampService implements ICampService {
       throw error;
     }
 
-    return{
+    return {
       id: campId,
       active: camp.active,
       ageLower: camp.ageLower,
@@ -139,7 +139,7 @@ class CampService implements ICampService {
         formQuestion.toString(),
       ),
       volunteers: camp.volunteers,
-    }
+    };
   }
 
   async updateCampById(campId: string, camp: UpdateCampDTO): Promise<CampDTO> {

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -18,8 +18,8 @@ interface ICampService {
    */
   getCamps(): Promise<GetCampDTO[]>;
 
-   /**
-   * Get camp with the specified campId 
+  /**
+   * Get camp with the specified campId
    * @param campId camp's id
    * @returns a CampDTO
    * @throws Error if camper retrieval fails

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -18,6 +18,8 @@ interface ICampService {
    */
   getCamps(): Promise<GetCampDTO[]>;
 
+  getCampById(campId: string): Promise<CampDTO>;
+
   createCamp(camp: CreateCampDTO): Promise<CampDTO>;
 
   deleteCamp(campId: string): Promise<void>;

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -18,6 +18,12 @@ interface ICampService {
    */
   getCamps(): Promise<GetCampDTO[]>;
 
+   /**
+   * Get camp with the specified campId 
+   * @param campId camp's id
+   * @returns a CampDTO
+   * @throws Error if camper retrieval fails
+   */
   getCampById(campId: string): Promise<CampDTO>;
 
   createCamp(camp: CreateCampDTO): Promise<CampDTO>;

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -24,7 +24,7 @@ interface ICampService {
    * @returns a CampDTO
    * @throws Error if camper retrieval fails
    */
-  getCampById(campId: string): Promise<CampDTO>;
+  getCampById(campId: string): Promise<GetCampDTO>;
 
   createCamp(camp: CreateCampDTO): Promise<CampDTO>;
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Get Camp by camp id](https://www.notion.so/uwblueprintexecs/Get-Camp-by-camp-id-a2d958a9e0de4f60bc3c47dd5a5968db)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added a getCampById end point to retrieve a camp by its Id 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. send a get request at `http://localhost:5000/camp/:id` 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* does the endpoint return all requested information? 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
