### PR TITLE
Fix: Fix Navbar Centering

### DIFF
--- a/frontend/src/components/common/NavBar.tsx
+++ b/frontend/src/components/common/NavBar.tsx
@@ -80,21 +80,30 @@ const NavBar = (): JSX.Element => {
       >
         {authenticatedUser ? (
           <>
-            <Image
-              src={FONIcon}
-              alt="FON icon"
-              display="inline"
-              width="40px"
-              height="40px"
-            />
+            <div
+              style={{
+                display: "flex",
+                flex: "1",
+                minWidth: "40px",
+              }}
+            >
+              <Image
+                src={FONIcon}
+                alt="FON icon"
+                display="inline"
+                width="40px"
+                height="40px"
+              />
+            </div>
             <Tabs
               variant="unstyled"
               onChange={navigate}
               defaultIndex={getIndex as any}
-              width="750px"
+              width="650px"
               alignContent="center"
+              isFitted
             >
-              <TabList justifyContent="space-evenly">
+              <TabList>
                 <Tab
                   id="Camps"
                   _selected={{
@@ -131,41 +140,45 @@ const NavBar = (): JSX.Element => {
                 )}
               </TabList>
             </Tabs>
-            <Popover placement="bottom-start" matchWidth>
-              {({ isOpen }) => (
-                <>
-                  <PopoverTrigger>
-                    <Button
-                      rightIcon={
-                        isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />
-                      }
-                      bg="background.white.100"
-                      _hover={{
-                        color: "none",
-                      }}
-                      _active={{
-                        color: "none",
-                      }}
-                      _focus={{
-                        color: "none",
-                      }}
-                    >
-                      {authenticatedUser?.firstName}{" "}
-                      {authenticatedUser?.lastName}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent width="inherit">
-                    <PopoverBody
-                      as={Button}
-                      bg="background.white.100"
-                      onClick={onLogOutClick}
-                    >
-                      Logout
-                    </PopoverBody>
-                  </PopoverContent>
-                </>
-              )}
-            </Popover>
+            <div
+              style={{ display: "flex", flex: "1", justifyContent: "flex-end" }}
+            >
+              <Popover placement="bottom-start" matchWidth>
+                {({ isOpen }) => (
+                  <>
+                    <PopoverTrigger>
+                      <Button
+                        rightIcon={
+                          isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />
+                        }
+                        bg="background.white.100"
+                        _hover={{
+                          color: "none",
+                        }}
+                        _active={{
+                          color: "none",
+                        }}
+                        _focus={{
+                          color: "none",
+                        }}
+                      >
+                        {authenticatedUser?.firstName}{" "}
+                        {authenticatedUser?.lastName}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent width="inherit">
+                      <PopoverBody
+                        as={Button}
+                        bg="background.white.100"
+                        onClick={onLogOutClick}
+                      >
+                        Logout
+                      </PopoverBody>
+                    </PopoverContent>
+                  </>
+                )}
+              </Popover>
+            </div>
           </>
         ) : null}
       </Flex>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
Bug Fix

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/31112327/178118683-493bff6a-0fb0-430d-9f0b-ee497bc75459.png">

<img width="854" alt="image" src="https://user-images.githubusercontent.com/31112327/178118707-2cd6e483-8664-4f72-895f-689e3ec6d2c8.png">


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Centered columns by having left and right fill space (https://stackoverflow.com/questions/29503227/how-to-make-flexbox-items-the-same-size)
* Centered the tabs using isFitted property


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visual test, verify for small screen widths
2. Test for long names


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Not sure about cases where not all the tabs are shown 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
