### PR TITLE
Feat: Update Waitlisted Camper to "Registered" after Camper is Created

### DIFF
--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -23,7 +23,10 @@ const camperService: ICamperService = new CamperService();
 camperRouter.post("/register", createCampersDtoValidator, async (req, res) => {
   try {
     const campers = req.body as CreateCampersDTO;
-    const newCampers = await camperService.createCampers(campers);
+    const newCampers = await camperService.createCampers(
+      campers,
+      req.query?.wId as string,
+    );
     res.status(201).json(newCampers);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -147,13 +147,22 @@ class CamperService implements ICamperService {
     });
 
     if (waitlistedCamperId) {
-      await MgWaitlistedCamper.findByIdAndUpdate(
-        waitlistedCamperId,
-        {
-          status: "Registered",
-        },
-        { runValidators: true },
-      );
+      try {
+        await MgWaitlistedCamper.findByIdAndUpdate(
+          waitlistedCamperId,
+          {
+            status: "Registered",
+          },
+          { runValidators: true },
+        );
+      } catch (error) {
+        Logger.error(
+          `Registered campers but was unable to update waitlisted camper status with id: ${waitlistedCamperId}. Error: ${getErrorMessage(
+            error,
+          )}`,
+        );
+        throw error;
+      }
     }
 
     return newCamperDTOs;

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -10,10 +10,14 @@ interface ICamperService {
   /**
    * Create a camper
    * @param campers the campers to be created
+   * @param waitlistedCamperId the waitlistedCamperIds to be set to registered
    * @returns an array of CamperDTO with the created campers' information
    * @throws Error if user creation fails
    */
-  createCampers(campers: CreateCampersDTO): Promise<Array<CamperDTO>>;
+  createCampers(
+    campers: CreateCampersDTO,
+    waitlistedCamperId?: string,
+  ): Promise<Array<CamperDTO>>;
 
   /**
    * Get all campers and their information
@@ -84,7 +88,7 @@ interface ICamperService {
    * @param waitlistedCamperId waitlisted camper's Id
    * @throws Error if waitlisted camper's status update fails
    */
-  inviteWaitlistedCamper(waitlistedCamperId: string): Promise<any>;
+  inviteWaitlistedCamper(waitlistedCamperId: string): Promise<unknown>;
 
   /**
    * Delete waitlisted camper associated with the ID


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Waitlist-Update-status-of-waitlisted-camper-who-registers-4e33b329a79f41749509158c745e39ec)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added check to ensure only one camper is being updated and then updated the field on waitlisted camper


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. ensure endpoint works as expected and changes a waitlisted camper put into query params


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Right now, we are making createCampers work as an endpoint that returns multiple campers. However, we can only change one waitlisted camper at a time since there is no other way to relate a waitlisted camper to their information without it getting unnecessarily complex. As such, should this be abstracted out into another endpoint that would only create one camper (would call createCampers function but only feed one camper) and all the waitlistedCamper logic would go into that?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
