### PR TITLE
feat: return camp photo link in get camp endpoint

### DIFF
--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -77,9 +77,17 @@ class CampService implements ICampService {
             }),
           );
 
-          let campPhotoUrl = "";
+          let campPhotoUrl;
           if (camp.fileName) {
-            campPhotoUrl = await this.storageService.getFile(camp.fileName);
+            try {
+              campPhotoUrl = await this.storageService.getFile(camp.fileName);
+            } catch (error: unknown) {
+              Logger.error(
+                `Failed to get camp photo for camp with id ${
+                  camp.id
+                }. Reason = ${getErrorMessage(error)}`,
+              );
+            }
           }
 
           return {
@@ -174,9 +182,17 @@ class CampService implements ICampService {
       throw error;
     }
 
-    let campPhotoUrl = "";
+    let campPhotoUrl;
     if (camp.fileName) {
-      campPhotoUrl = await this.storageService.getFile(camp.fileName);
+      try {
+        campPhotoUrl = await this.storageService.getFile(camp.fileName);
+      } catch (error: unknown) {
+        Logger.error(
+          `Failed to get camp photo for camp with id ${
+            camp.id
+          }. Reason = ${getErrorMessage(error)}`,
+        );
+      }
     }
 
     if (waitlistedCamperId) {

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -49,54 +49,62 @@ class CampService implements ICampService {
         return [];
       }
 
-      return camps.map((camp) => {
-        const formQuestions = (camp.formQuestions as FormQuestion[]).map(
-          (formQuestion: FormQuestion) => {
-            return {
-              id: formQuestion.id,
-              type: formQuestion.type,
-              question: formQuestion.question,
-              required: formQuestion.required,
-              description: formQuestion.description,
-              options: formQuestion.options,
-            };
-          },
-        );
+      return await Promise.all(
+        camps.map(async (camp) => {
+          const formQuestions = (camp.formQuestions as FormQuestion[]).map(
+            (formQuestion: FormQuestion) => {
+              return {
+                id: formQuestion.id,
+                type: formQuestion.type,
+                question: formQuestion.question,
+                required: formQuestion.required,
+                description: formQuestion.description,
+                options: formQuestion.options,
+              };
+            },
+          );
 
-        const campSessions = (camp.campSessions as CampSession[]).map(
-          (campSession) => ({
-            id: campSession.id,
-            capacity: campSession.capacity,
-            dates: campSession.dates.map((date) => date.toString()),
-            registrations: campSession.campers.length,
-            waitlist: campSession.waitlist.length,
-          }),
-        );
+          const campSessions = (camp.campSessions as CampSession[]).map(
+            (campSession) => ({
+              id: campSession.id,
+              capacity: campSession.capacity,
+              dates: campSession.dates.map((date) => date.toString()),
+              registrations: campSession.campers.length,
+              waitlist: campSession.waitlist.length,
+            }),
+          );
 
-        return {
-          id: camp.id,
-          active: camp.active,
-          ageLower: camp.ageLower,
-          ageUpper: camp.ageUpper,
-          campCoordinators: camp.campCoordinators.map((coordinator) =>
-            coordinator.toString(),
-          ),
-          campCounsellors: camp.campCounsellors.map((counsellor) =>
-            counsellor.toString(),
-          ),
-          name: camp.name,
-          description: camp.description,
-          earlyDropoff: camp.earlyDropoff,
-          latePickup: camp.latePickup,
-          location: camp.location,
-          startTime: camp.startTime,
-          endTime: camp.endTime,
-          fee: camp.fee,
-          formQuestions,
-          campSessions,
-          volunteers: camp.volunteers,
-        };
-      });
+          let campPhotoUrl = "";
+          if (camp.fileName) {
+            campPhotoUrl = await this.storageService.getFile(camp.fileName);
+          }
+
+          return {
+            id: camp.id,
+            active: camp.active,
+            ageLower: camp.ageLower,
+            ageUpper: camp.ageUpper,
+            campCoordinators: camp.campCoordinators.map((coordinator) =>
+              coordinator.toString(),
+            ),
+            campCounsellors: camp.campCounsellors.map((counsellor) =>
+              counsellor.toString(),
+            ),
+            name: camp.name,
+            description: camp.description,
+            earlyDropoff: camp.earlyDropoff,
+            latePickup: camp.latePickup,
+            location: camp.location,
+            startTime: camp.startTime,
+            endTime: camp.endTime,
+            fee: camp.fee,
+            formQuestions,
+            campSessions,
+            volunteers: camp.volunteers,
+            campPhotoUrl,
+          };
+        }),
+      );
     } catch (error: unknown) {
       Logger.error(`Failed to get camps. Reason = ${getErrorMessage(error)}`);
       throw error;
@@ -123,6 +131,11 @@ class CampService implements ICampService {
     } catch (error: unknown) {
       Logger.error(`Failed to get camp. Reason = ${getErrorMessage(error)}`);
       throw error;
+    }
+
+    let campPhotoUrl = "";
+    if (camp.fileName) {
+      campPhotoUrl = await this.storageService.getFile(camp.fileName);
     }
 
     return {
@@ -164,6 +177,7 @@ class CampService implements ICampService {
         },
       ),
       volunteers: camp.volunteers,
+      campPhotoUrl,
     };
   }
 

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -130,8 +130,7 @@ export type GetCampDTO = Omit<CampDTO, "campSessions" | "formQuestions"> & {
     CampSessionDTO,
     "id" | "camp" | "campers" | "waitlist"
   > & { registrations: number; waitlist: number })[];
-  filePath?: string;
-  fileContentType?: string;
+  campPhotoUrl?: string;
 };
 
 export type CreateCampDTO = Omit<


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview Photo](https://www.notion.so/uwblueprintexecs/Camp-Overview-Camp-Photos-3c56402473f646c4a6b985a9925969ea)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Returning a link to the camp photo in the get camps endpoint in the `campPhotoUrl` field


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Make GET requests to http://localhost:5000/camp/
2. Check that the correct link is returned.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
