### PR TITLE
Feat: Implement change user role to access control table

### DIFF
--- a/frontend/src/APIClients/UserAPIClient.ts
+++ b/frontend/src/APIClients/UserAPIClient.ts
@@ -1,6 +1,6 @@
 import { BEARER_TOKEN } from "../constants/AuthConstants";
 import baseAPIClient from "./BaseAPIClient";
-import { UserResponse } from "../types/UserTypes";
+import { UserRequest, UserResponse } from "../types/UserTypes";
 
 const getAllUsers = async (): Promise<UserResponse[]> => {
   try {
@@ -13,6 +13,21 @@ const getAllUsers = async (): Promise<UserResponse[]> => {
   }
 };
 
+const updateUserById = async (
+  id: string,
+  userData: UserRequest,
+): Promise<boolean> => {
+  try {
+    const { data } = await baseAPIClient.put(`/users/${id}`, userData, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export default {
   getAllUsers,
+  updateUserById,
 };

--- a/frontend/src/types/UserTypes.ts
+++ b/frontend/src/types/UserTypes.ts
@@ -1,5 +1,14 @@
 import { Role } from "./AuthTypes";
 
+export type UserRequest = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: Role;
+  active: boolean;
+};
+
 export type UserResponse = {
   id: string;
   firstName: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Access Management: Change User Role](https://www.notion.so/uwblueprintexecs/Access-Management-Change-User-Role-52f1f83dcba04aa6a27400298ba900f8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add functionality to change a user's role from FON Admin -> Camp Coordinator and vice versa


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as an Admin and go to the Access Control table
2. Select a user to change a role in the row's dropdown
3. Upon successful change, a success toast message should appear.
4. Go to MongoDB and make sure the change is reflected in the DB


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
