### PR TITLE
feat: support multi-session registration and refunds

### DIFF
--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -12,6 +12,7 @@ import {
   CreateWaitlistedCamperDTO,
   WaitlistedCamperDTO,
   UpdateCamperDTO,
+  FON_ADMIN_EMAIL,
 } from "../../types";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
@@ -671,9 +672,9 @@ class CamperService implements ICamperService {
         diffInMilliseconds / (1000 * 60 * 60 * 24),
       );
 
-      if (daysUntilStartOfCamp < 30 && campSession.waitlist.length === 0) {
+      if (daysUntilStartOfCamp < 30) {
         throw new Error(
-          `Campers' camp session with campId ${campersToBeDeleted[0].campSession} has a start date in less than 30 days and the waitlist is empty.`,
+          `Campers' camp session with campId ${campersToBeDeleted[0].campSession} has a start date in less than 30 days. Contact FON at ${FON_ADMIN_EMAIL} for a refund.`,
         );
       }
 

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -1,3 +1,5 @@
+export const FON_ADMIN_EMAIL = "camps@focusonnature.ca";
+
 export type Role = "Admin" | "CampCoordinator";
 
 export type DropOffType = "EarlyDropOff" | "LatePickUp";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
So far:
* removed the waitlist check on refunding - now throws error if parent tries to refund within 30 days of start date regardless of waitlist status 

To do:
* multi-session registrations
* multi-session refunds

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
