### PR TITLE
feat: Implement access control table change status function

### DIFF
--- a/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
+++ b/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
@@ -33,11 +33,11 @@ const ConfirmStatusChangeModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay />
-      <ModalContent py="22px" px="16px">
+      <ModalContent>
         <ModalHeader>
           <Text textStyle="heading">{title}</Text>
         </ModalHeader>
-        <ModalBody textStyle="mobileBody" color="hubbard.100">
+        <ModalBody textStyle="bodyRegular" color="text.default.100">
           {bodyText}
         </ModalBody>
         <ModalFooter>

--- a/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
+++ b/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
@@ -1,0 +1,62 @@
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import React from "react";
+
+interface ConfirmStatusChangeModalProps {
+  title: string;
+  bodyText: string;
+  buttonLabel: string;
+  buttonColor: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onChangeStatus: () => void;
+}
+
+const ConfirmStatusChangeModal = ({
+  title,
+  bodyText,
+  buttonLabel,
+  buttonColor,
+  isOpen,
+  onClose,
+  onChangeStatus,
+}: ConfirmStatusChangeModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent py="22px" px="16px">
+        <ModalHeader>
+          <Text textStyle="heading">{title}</Text>
+        </ModalHeader>
+        <ModalBody textStyle="mobileBody" color="hubbard.100">
+          {bodyText}
+        </ModalBody>
+        <ModalFooter>
+          <HStack>
+            <Button onClick={onChangeStatus} padding="20px">
+              Cancel
+            </Button>
+            <Button
+              colorScheme={buttonColor}
+              onClick={onChangeStatus}
+              padding="20px"
+            >
+              {buttonLabel}
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ConfirmStatusChangeModal;

--- a/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
+++ b/frontend/src/components/pages/AccessControl/ConfirmStatusChangeModal.tsx
@@ -42,7 +42,7 @@ const ConfirmStatusChangeModal = ({
         </ModalBody>
         <ModalFooter>
           <HStack>
-            <Button onClick={onChangeStatus} padding="20px">
+            <Button onClick={onClose} padding="20px">
               Cancel
             </Button>
             <Button

--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -7,6 +7,10 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   Table,
   Tag,
@@ -114,6 +118,10 @@ const AccessControlPage = (): JSX.Element => {
     }
   };
 
+  const handleStatusChange = () => {
+    // onOpen();
+  };
+
   return (
     <Container
       maxWidth="100vw"
@@ -202,11 +210,25 @@ const AccessControlPage = (): JSX.Element => {
                 />
               </Td>
               <Td>
-                <IconButton
-                  aria-label="Mark as active button"
-                  icon={<FaEllipsisV />}
-                  variant=""
-                />
+                <Popover>
+                  <PopoverTrigger>
+                    <IconButton
+                      aria-label="Mark as active button"
+                      icon={<FaEllipsisV />}
+                      variant=""
+                      onClick={handleStatusChange}
+                    />
+                  </PopoverTrigger>
+                  <PopoverContent>
+                  <PopoverBody
+                        as={Button}
+                        bg="background.white.100"
+            
+                      >
+                        Logout
+                      </PopoverBody>
+                  </PopoverContent>
+                </Popover>
               </Td>
             </Tr>
           ))}

--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -300,7 +300,7 @@ const AccessControlPage = (): JSX.Element => {
                 />
               </Td>
               <Td>
-                <Popover>
+                <Popover placement="bottom-end">
                   <PopoverTrigger>
                     <IconButton
                       aria-label="Mark as active button"
@@ -314,10 +314,12 @@ const AccessControlPage = (): JSX.Element => {
                       bg="background.white.100"
                       onClick={(e) => handleStatusChangePopoverTrigger(user)}
                     >
-                      Mark as{" "}
-                      {user.active
-                        ? UserStatusStates.INACTIVE_NO_CAP
-                        : UserStatusStates.ACTIVE_NO_CAP}
+                      <Text textStyle="buttonRegular">
+                        Mark as{" "}
+                        {user.active
+                          ? UserStatusStates.INACTIVE_NO_CAP
+                          : UserStatusStates.ACTIVE_NO_CAP}
+                      </Text>
                     </PopoverBody>
                   </PopoverContent>
                 </Popover>

--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -33,10 +33,12 @@ import { Role } from "../../../types/AuthTypes";
 import ConfirmStatusChangeModal from "./ConfirmStatusChangeModal";
 
 const AccessControlPage = (): JSX.Element => {
-  enum Filter {
+  enum UserStatusStates {
     ALL = "All",
-    ACTIVE = "Active",
-    INACTIVE = "Inactive",
+    ACTIVE_CAPITALIZED = "Active",
+    INACTIVE_CAPITALIZED = "Inactive",
+    ACTIVE_NO_CAP = "active",
+    INACTIVE_NO_CAP = "inactive",
   }
 
   enum UserRoles {
@@ -44,13 +46,17 @@ const AccessControlPage = (): JSX.Element => {
     CAMP_COORDINATOR = "Camp Coordinator",
   }
 
-  const filterOptions = [Filter.ALL, Filter.ACTIVE, Filter.INACTIVE];
+  const filterOptions = [
+    UserStatusStates.ALL,
+    UserStatusStates.ACTIVE_CAPITALIZED,
+    UserStatusStates.INACTIVE_CAPITALIZED,
+  ];
   const userRoles = [UserRoles.ADMIN, UserRoles.CAMP_COORDINATOR];
 
   const [users, setUsers] = React.useState([] as UserResponse[]);
   const [search, setSearch] = React.useState("");
-  const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
-    Filter.ALL,
+  const [selectedFilter, setSelectedFilter] = React.useState<UserStatusStates>(
+    UserStatusStates.ALL,
   );
   const [
     userToChangeStatus,
@@ -71,8 +77,8 @@ const AccessControlPage = (): JSX.Element => {
 
   const tableData = React.useMemo(() => {
     let filteredUsers;
-    if (selectedFilter === Filter.ALL) filteredUsers = users;
-    else if (selectedFilter === Filter.ACTIVE)
+    if (selectedFilter === UserStatusStates.ALL) filteredUsers = users;
+    else if (selectedFilter === UserStatusStates.ACTIVE_CAPITALIZED)
       filteredUsers = users.filter((user) => user.active);
     else filteredUsers = users.filter((user) => !user.active);
 
@@ -188,14 +194,22 @@ const AccessControlPage = (): JSX.Element => {
       <ConfirmStatusChangeModal
         title={`Mark ${userToChangeStatus?.firstName} ${
           userToChangeStatus?.lastName
-        } as ${userToChangeStatus?.active ? Filter.INACTIVE : Filter.ACTIVE}`}
+        } as ${
+          userToChangeStatus?.active
+            ? UserStatusStates.INACTIVE_NO_CAP
+            : UserStatusStates.ACTIVE_NO_CAP
+        }`}
         bodyText={`Are you sure you want to mark ${
           userToChangeStatus?.firstName
         } ${userToChangeStatus?.lastName} as ${
-          userToChangeStatus?.active ? Filter.INACTIVE : Filter.ACTIVE
+          userToChangeStatus?.active
+            ? UserStatusStates.INACTIVE_NO_CAP
+            : UserStatusStates.ACTIVE_NO_CAP
         }?`}
         buttonLabel={`Mark as ${
-          userToChangeStatus?.active ? Filter.INACTIVE : Filter.ACTIVE
+          userToChangeStatus?.active
+            ? UserStatusStates.INACTIVE_NO_CAP
+            : UserStatusStates.ACTIVE_NO_CAP
         }`}
         buttonColor={userToChangeStatus?.active ? "red" : "green"}
         isOpen={isOpen}
@@ -232,7 +246,7 @@ const AccessControlPage = (): JSX.Element => {
                   borderRadius="full"
                   variant={selectedFilter === option ? "solid" : "outline"}
                   colorScheme={selectedFilter === option ? "green" : "gray"}
-                  px={option === Filter.ALL ? "2em" : "1em"}
+                  px={option === UserStatusStates.ALL ? "2em" : "1em"}
                   onClick={() => setSelectedFilter(option)}
                 >
                   <TagLabel>{option}</TagLabel>
@@ -278,7 +292,11 @@ const AccessControlPage = (): JSX.Element => {
               <Td pl="0px">
                 <UserStatusLabel
                   active={user.active}
-                  value={user.active ? Filter.ACTIVE : Filter.INACTIVE}
+                  value={
+                    user.active
+                      ? UserStatusStates.ACTIVE_CAPITALIZED
+                      : UserStatusStates.INACTIVE_CAPITALIZED
+                  }
                 />
               </Td>
               <Td>
@@ -296,7 +314,10 @@ const AccessControlPage = (): JSX.Element => {
                       bg="background.white.100"
                       onClick={(e) => handleStatusChangePopoverTrigger(user)}
                     >
-                      Mark as {user.active ? Filter.INACTIVE : Filter.ACTIVE}
+                      Mark as{" "}
+                      {user.active
+                        ? UserStatusStates.INACTIVE_NO_CAP
+                        : UserStatusStates.ACTIVE_NO_CAP}
                     </PopoverBody>
                   </PopoverContent>
                 </Popover>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Access Management: Change user status](https://www.notion.so/uwblueprintexecs/Access-Management-Change-user-status-549c554ea8f14db5a7dee9ab43de28aa)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added onClick handler to the 3 dots symbol for each row to show a confirmation modal popup and allows user to mark a user in the table as inactive or active


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as an admin and go to the Access Control table
2. Choose a user that is active, and mark them as inactive. They should properly be updated in MongoDB and a success toast should be displayed.
3. Choose a user that is inactive, and mark them as active. This should also be updated in MongoDB and a success toast should be displayed.
4. Make sure the designs accurately match


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Coding practices
* Make sure components match designs


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
