### PR TITLE
Feat: Camp List Page Header

### DIFF
--- a/frontend/src/components/pages/CampsList/CampsNavigationHeader.tsx
+++ b/frontend/src/components/pages/CampsList/CampsNavigationHeader.tsx
@@ -1,0 +1,77 @@
+import { Flex, Text, Box, IconButton, Button } from "@chakra-ui/react";
+import React from "react";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faChevronLeft,
+  faChevronRight,
+  faPlus,
+} from "@fortawesome/free-solid-svg-icons";
+import textStyles from "../../../theme/textStyles";
+
+const CampsNavigationHeader = ({
+  year,
+  onNavigateLeft,
+  onNavigateRight,
+}: {
+  year: number;
+  onNavigateLeft: () => void;
+  onNavigateRight: () => void;
+}): React.ReactElement => {
+  return (
+    <Box>
+      <Text
+        fontWeight={textStyles.displayXLarge.fontWeight}
+        fontSize={textStyles.displayXLarge.fontSize}
+      >
+        FON Camps
+      </Text>
+      <Flex
+        direction="row"
+        marginTop="16px"
+        alignItems="flex-end"
+        justifyContent="space-between"
+      >
+        <Flex direction="row" alignItems="center">
+          <IconButton
+            icon={<FontAwesomeIcon icon={faChevronLeft} />}
+            fontSize="32px"
+            aria-label="back-button"
+            onClick={onNavigateLeft}
+            backgroundColor="background.white.100"
+          />
+          <Text
+            fontWeight={textStyles.displayXLarge.fontWeight}
+            fontSize={textStyles.displayXLarge.fontSize}
+            marginLeft="16px"
+            marginRight="16px"
+          >
+            {year}
+          </Text>
+          <IconButton
+            icon={<FontAwesomeIcon icon={faChevronRight} />}
+            fontSize="32px"
+            aria-label="forward-button"
+            onClick={onNavigateRight}
+            backgroundColor="background.white.100"
+          />
+        </Flex>
+        <Button
+          leftIcon={<FontAwesomeIcon icon={faPlus} />}
+          aria-label="Add Camp"
+          type="submit"
+          border="2px"
+          borderRadius="5px"
+          color="primary.green.100"
+          background="background.grey.200"
+          borderColor="primary.green.100"
+          minWidth="-webkit-fit-content"
+        >
+          Add Camp
+        </Button>
+      </Flex>
+    </Box>
+  );
+};
+
+export default CampsNavigationHeader;

--- a/frontend/src/components/pages/CampsList/CampsNavigationHeading.tsx
+++ b/frontend/src/components/pages/CampsList/CampsNavigationHeading.tsx
@@ -20,12 +20,7 @@ const CampsNavigationHeading = ({
 }): React.ReactElement => {
   return (
     <Box>
-      <Text
-        fontWeight={textStyles.displayXLarge.fontWeight}
-        fontSize={textStyles.displayXLarge.fontSize}
-      >
-        FON Camps
-      </Text>
+      <Text textStyle="displayXLarge">FON Camps</Text>
       <Flex
         direction="row"
         marginTop="16px"

--- a/frontend/src/components/pages/CampsList/CampsNavigationHeading.tsx
+++ b/frontend/src/components/pages/CampsList/CampsNavigationHeading.tsx
@@ -9,7 +9,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import textStyles from "../../../theme/textStyles";
 
-const CampsNavigationHeader = ({
+const CampsNavigationHeading = ({
   year,
   onNavigateLeft,
   onNavigateRight,
@@ -74,4 +74,4 @@ const CampsNavigationHeader = ({
   );
 };
 
-export default CampsNavigationHeader;
+export default CampsNavigationHeading;

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import CampsNavigationHeader from "./CampsNavigationHeader";
+import CampsNavigationHeading from "./CampsNavigationHeading";
 
 const CampsListPage = (): React.ReactElement => {
   const [year, setYear] = useState(2022);
   return (
     <>
-      <CampsNavigationHeader
+      <CampsNavigationHeading
         year={year}
         onNavigateLeft={() => setYear(year - 1)}
         onNavigateRight={() => setYear(year + 1)}

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import CampsNavigationHeading from "./CampsNavigationHeading";
 
 const CampsListPage = (): React.ReactElement => {
-  const [year, setYear] = useState(2022);
+  const [year, setYear] = useState(new Date().getFullYear());
   return (
     <>
       <CampsNavigationHeading

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from "react";
+import CampsNavigationHeader from "./CampsNavigationHeader";
+
+const CampsListPage = (): React.ReactElement => {
+  const [year, setYear] = useState(2022);
+  return (
+    <>
+      <CampsNavigationHeader
+        year={year}
+        onNavigateLeft={() => setYear(year - 1)}
+        onNavigateRight={() => setYear(year + 1)}
+      />
+    </>
+  );
+};
+
+export default CampsListPage;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp List: Page heading + navigation](https://www.notion.so/uwblueprintexecs/Task-Board-S22-1a3e651ab8544192bf0fdcbba04f6d03?p=751be149873441978d6dda7f4ef202bd&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Built a component for just the heading of the Camps List, with buttons for navigation between years


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test out dummy page under CampsList
2. Attempt integrating with Camp List Table page

<img width="640" alt="image" src="https://user-images.githubusercontent.com/31112327/188286678-4fdedd1a-c0b1-429a-8b4a-aaf7b9b0be24.png">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Does the component match designs


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
