### PR TITLE
fix: get users

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - "frontend/**"
       - "backend/typescript/**"
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - "frontend/**"
       - "backend/typescript/**"
@@ -22,7 +24,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Filter changed files
         uses: dorny/paths-filter@v2
         id: changes
@@ -34,7 +36,7 @@ jobs:
               - "backend/typescript/**"
             python-backend:
               - "backend/python/**"
-      
+
       - name: Set up Node.js
         if: steps.changes.outputs.frontend == 'true' || steps.changes.outputs.typescript-backend == 'true'
         uses: actions/setup-node@v2
@@ -58,7 +60,7 @@ jobs:
         if: steps.changes.outputs.typescript-backend == 'true'
         working-directory: ./backend/typescript
         run: yarn lint
-      
+
       - name: Lint Python backend
         if: steps.changes.outputs.python-backend == 'true'
         working-directory: ./backend/python

--- a/frontend/src/APIClients/UserAPIClient.ts
+++ b/frontend/src/APIClients/UserAPIClient.ts
@@ -9,7 +9,7 @@ const getAllUsers = async (): Promise<Array<UserResponse>> => {
     });
     return data;
   } catch (error) {
-    return error as UserResponse[];
+    return [];
   }
 };
 

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -38,7 +38,7 @@ const CampOverviewPage = (): JSX.Element => {
     volunteers: "",
     campPhotoUrl: "",
   });
-  const numSessions = camp.campSessions.length;
+  const numSessions = camp.campSessions?.length;
 
   useEffect(() => {
     const getCamp = async () => {
@@ -80,7 +80,7 @@ const CampOverviewPage = (): JSX.Element => {
         </Text>
         <CampDetails camp={camp} setCamp={setCamp} />
         <Divider borderColor="background.grey.400" marginY="32px" />
-        {camp.campSessions.length > 0 ? (
+        {camp.campSessions?.length > 0 ? (
           <>
             <CampSessionInfoHeader
               camp={camp}


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Currently when calling the get users endpoint, the entire request fails when one user is invalid (i.e. lookup in Firebase auth fails). Instead of failing the entire request we want to return the valid users.
- Adding some nullchecks where the UI was crashing
- Adding linting checks on dev branch

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Remove the `authId` field on a dummy user in the db to make this user invalid (or make a new entry leaving out the `authId` field).
2. Make a GET request to /users (navigating to a camp details page when you're signed in as an admin is an easy way to do this, can use http://localhost:3000/admin/camp/63139c7bc3d7b55b44a01531). 
3. Check in the network tab that the request to /users was successful and has returned users.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
