### PR TITLE
Create DELETE endpoint for multiple camp sessions

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -360,6 +360,25 @@ export const updateCampSessionDtoValidator = async (
   return next();
 };
 
+/* eslint-disable-next-line import/prefer-default-export */
+export const deleteCampSessionsDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.body.campSessionIds) {
+    const { campSessionIds } = req.body;
+    if (!validateArray(campSessionIds, "string")) {
+      return res
+        .status(400)
+        .send(getApiValidationError("campSessionIds", "string", true));
+    }
+  } else {
+    return res.status(400).send("campSessionIds does not exist");
+  }
+  return next();
+};
+
 export const editFormQuestionValidator = async (
   req: Request,
   res: Response,

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -10,6 +10,7 @@ import {
   createCampDtoValidator,
   createCampSessionsDtoValidator,
   createFormQuestionsValidator,
+  deleteCampSessionsDtoValidator,
   editFormQuestionValidator,
   updateCampDtoValidator,
   updateCampSessionDtoValidator,
@@ -195,17 +196,21 @@ campRouter.delete("/:campId/session/:campSessionId", async (req, res) => {
 });
 
 /* Delete camp sessions */
-campRouter.delete("/:campId/session/", async (req, res) => {
-  try {
-    await campService.deleteCampSessionsByIds(
-      req.params.campId,
-      req.body.campSessionIds,
-    );
-    res.status(204).send();
-  } catch (error: unknown) {
-    res.status(500).json({ error: getErrorMessage(error) });
-  }
-});
+campRouter.delete(
+  "/:campId/session/",
+  deleteCampSessionsDtoValidator,
+  async (req, res) => {
+    try {
+      await campService.deleteCampSessionsByIds(
+        req.params.campId,
+        req.body.campSessionIds,
+      );
+      res.status(204).send();
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  },
+);
 
 /* Returns a CSV string containing all campers within a specific camp */
 campRouter.get("/csv/:id", async (req, res) => {

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -194,6 +194,19 @@ campRouter.delete("/:campId/session/:campSessionId", async (req, res) => {
   }
 });
 
+/* Delete camp sessions */
+campRouter.delete("/:campId/session/", async (req, res) => {
+  try {
+    await campService.deleteCampSessionsByIds(
+      req.params.campId,
+      req.body.campSessionIds,
+    );
+    res.status(204).send();
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 /* Returns a CSV string containing all campers within a specific camp */
 campRouter.get("/csv/:id", async (req, res) => {
   try {

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -41,6 +41,11 @@ interface ICampService {
 
   deleteCampSessionById(campId: string, campSessionId: string): Promise<void>;
 
+  deleteCampSessionsByIds(
+    campId: string,
+    campSessionIds: Array<string>,
+  ): Promise<void>;
+
   createCampSessions(
     campId: string,
     campSessions: CreateCampSessionsDTO,

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -177,6 +177,11 @@ export type CreateCampSessionsDTO = Array<
   Omit<CampSessionDTO, "id" | "camp" | "campers" | "waitlist" | "campPriceId">
 >;
 
+// export type CampSessionDTO = {
+//   capacity: number;
+//   dates: string[];
+// };
+
 export type UpdateCampSessionDTO = Omit<
   CampSessionDTO,
   "id" | "camp" | "campers" | "waitlist" | "campPriceId"


### PR DESCRIPTION
## Notion ticket link
[Camp Overview: Delete Session + Change Session Capacity](https://www.notion.so/uwblueprintexecs/8902e20b0cae4db2b4776259238f8a4e?v=4cf916ddabfc4438a2685c0990a4fc57&p=6d18cb517d61447ab691f8a7d37978f6&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Note that implementation is different that `deleteCampersById`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Make a DELETE call with existing camp sessions
3. Make a DELETE call with non-existing camp sessions


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Nothing specific, is the approach readable and does it makes sense?
  * better approach would use transactions


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
