### PR TITLE
Change toast styling to subtle

### DIFF
--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -111,8 +111,8 @@ const AccessControlPage = (): JSX.Element => {
           newRole === Role.ADMIN ? UserRoles.ADMIN : UserRoles.CAMP_COORDINATOR
         }`,
         status: "success",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
 
       const newUsers: UserResponse[] = await users.map((u) => {
@@ -126,8 +126,8 @@ const AccessControlPage = (): JSX.Element => {
       toast({
         description: `An error occurred with changing ${user.firstName} ${user.lastName}'s role. Please try again.`,
         status: "error",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
     }
   };
@@ -158,8 +158,8 @@ const AccessControlPage = (): JSX.Element => {
               user!.lastName
             } can no longer access the Camp Management Tool`,
         status: "success",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
 
       const newUsers: UserResponse[] = await users.map((u) => {
@@ -175,8 +175,8 @@ const AccessControlPage = (): JSX.Element => {
           user!.lastName
         }'s status. Please try again.`,
         status: "error",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
     }
     onClose();

--- a/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
@@ -81,15 +81,15 @@ const WaitlistedCampersTable = ({
         description:
           "Registration link has been sent and they will be notified.",
         status: "success",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
     } else {
       toast({
         description: "Registration link cannot be sent. Please try again.",
         status: "error",
-        duration: 7000,
-        isClosable: true,
+        variant: "subtle",
+        duration: 3000,
       });
     }
   };
@@ -112,15 +112,15 @@ const WaitlistedCampersTable = ({
         toast({
           description: `${camperToDeleteName} has been removed from the waitlist for this camp session.`,
           status: "success",
-          duration: 7000,
-          isClosable: true,
+          variant: "subtle",
+          duration: 3000,
         });
       } else {
         toast({
           description: `${camperToDeleteName} could not be deleted from this camp session.`,
           status: "error",
-          duration: 7000,
-          isClosable: true,
+          variant: "subtle",
+          duration: 3000,
         });
       }
     }

--- a/frontend/src/theme/colors.ts
+++ b/frontend/src/theme/colors.ts
@@ -19,7 +19,13 @@ const colors = {
     },
   },
   overlay: {
-    // TODO: to fill in
+    dark: {
+      50: "#00000080",
+      20: "#00000033",
+    },
+    blue: {
+      500: "#88CBFC80",
+    },
   },
   text: {
     default: {
@@ -57,15 +63,52 @@ const colors = {
       300: "#F4F4F4",
       400: "#D8DBDF",
     },
-    // TODO: to fill in
+    interactive: {
+      100: "#D3E9D3",
+    },
+    inactive: {
+      100: "#E4E5E7",
+    },
+    critical: {
+      100: "#FFF4F4",
+    },
+    warning: {
+      100: "#FFF5EA",
+    },
+    success: {
+      100: "#F1F8F5",
+    },
+    informative: {
+      100: "#EBF9FC",
+    },
+    tooltip: {
+      100: "#CDD5DF",
+    },
+    primary: {
+      100: "#D3E9D3",
+    },
   },
   border: {
-    // TODO: to fill in
     default: {
       100: "#8C9196",
     },
     secondary: {
       100: "#C9CCCF",
+    },
+    input: {
+      100: "#D8DBDF",
+    },
+    critical: {
+      100: "#E0B3B2",
+    },
+    warning: {
+      100: "#E1B878",
+    },
+    success: {
+      100: "#95C9B4",
+    },
+    informative: {
+      100: "#98C6CD",
     },
   },
   waitlistCards: {


### PR DESCRIPTION
## Notion ticket link


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Design request


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
-> setup one of the buttons as a demo

```ts
toast({
  description:
    "Registration link has been sent and they will be notified.",
  status: "success",
  variant: "subtle",
  duration: 3000,
});

toast({
  description:
    "Registration link has been sent and they will be notified.",
  status: "info",
  variant: "subtle",
  duration: 3000,
});

toast({
  description:
    "Registration link has been sent and they will be notified.",
  status: "warning",
  variant: "subtle",
  duration: 3000,
});

toast({
  description:
    "Registration link has been sent and they will be notified.",
  status: "error",
  variant: "subtle",
  duration: 3000,
});
```

https://user-images.githubusercontent.com/40974372/193250176-45f2445d-ea86-4abe-a402-996fe6cc17f8.mov





<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
