### PR TITLE
feat: Download CSV for Camp Session

### DIFF
--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -1160,7 +1160,9 @@ class CampService implements ICampService {
       const campersWithSpecficQuestions: string[] = [];
       campers.forEach((camper) => {
         camper.formResponses.forEach((value, key) => {
-          const campQuestion = formQuestionsData.find((item) => item.question == key);
+          const campQuestion = formQuestionsData.find(
+            (item) => item.question === key,
+          );
           if (campQuestion?.category === "CampSpecific") {
             campersWithSpecficQuestions.push(camper.id);
           }
@@ -1170,21 +1172,37 @@ class CampService implements ICampService {
       return await Promise.all(
         campers.map(async (camper) => {
           return {
-              "Registration Date": camper.registrationDate.toLocaleDateString('en-CA').toString(),
-              "Camper Name": camper.firstName + ' ' + camper.lastName,
-              "Camper Age": camper.age,
-              "Primary Emergency Contact Name": camper.contacts[0].firstName + ' ' + camper.contacts[0].lastName,
-              "Primary Emergency Contact Phone #": camper.contacts[0].phoneNumber,
-              "Primary Emergency Contact Email": camper.contacts[0].email,
-              "Secondary Emergency Contact Name": (camper.contacts.length > 1) ? camper.contacts[1].firstName + ' ' + camper.contacts[1].lastName : "",
-              "Secondary Emergency Contact Phone #": (camper.contacts.length > 1) ? camper.contacts[1].phoneNumber : "",
-              "Requires Early Drop-off": (camper.earlyDropoff.length > 0) ? "Y" : "N",
-              "Requires Late Pick-up": (camper.earlyDropoff.length > 0) ? "Y" : "N",
-              "Allergies": camper.allergies,
-              "Additional Accomodations": camper.specialNeeds,
-              "Amount Paid": camper.charges.camp + camper.charges.earlyDropoff + camper.charges.latePickup,
-              "Additional Camp-Specific Q's": (campersWithSpecficQuestions.includes(camper.id)) ? "Y" : "N",
-              "Additional Waiver Clauses": (camper.optionalClauses.length > 0) ? "Y" : "N",
+            "Registration Date": camper.registrationDate
+              .toLocaleDateString("en-CA")
+              .toString(),
+            "Camper Name": `${camper.firstName} ${camper.lastName}`,
+            "Camper Age": camper.age,
+            "Primary Emergency Contact Name": `${camper.contacts[0].firstName} ${camper.contacts[0].lastName}`,
+            "Primary Emergency Contact Phone #": camper.contacts[0].phoneNumber,
+            "Primary Emergency Contact Email": camper.contacts[0].email,
+            "Secondary Emergency Contact Name":
+              camper.contacts.length > 1
+                ? `${camper.contacts[1].firstName} ${camper.contacts[1].lastName}`
+                : "",
+            "Secondary Emergency Contact Phone #":
+              camper.contacts.length > 1 ? camper.contacts[1].phoneNumber : "",
+            "Requires Early Drop-off":
+              camper.earlyDropoff.length > 0 ? "Y" : "N",
+            "Requires Late Pick-up": camper.earlyDropoff.length > 0 ? "Y" : "N",
+            // eslint-disable-next-line
+            "Allergies": camper.allergies,
+            "Additional Accomodations": camper.specialNeeds,
+            "Amount Paid":
+              camper.charges.camp +
+              camper.charges.earlyDropoff +
+              camper.charges.latePickup,
+            "Additional Camp-Specific Q's": campersWithSpecficQuestions.includes(
+              camper.id,
+            )
+              ? "Y"
+              : "N",
+            "Additional Waiver Clauses":
+              camper.optionalClauses.length > 0 ? "Y" : "N",
           };
         }),
       );

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -1148,20 +1148,19 @@ class CampService implements ICampService {
         throw new Error(`Camp Session with id ${campSessionId} not found.`);
       }
       const campers = campSession.campers as Camper[];
-      
       const camp: Camp | null = await MgCamp.findById(campSession.camp);
       if (!camp) {
         throw new Error(`Camp with id ${campSessionId} not found.`);
       }
 
-      let formQuestionsData = await MgFormQuestion.find(
-        {'_id': { $in: camp.formQuestions }}
-      );
+      const formQuestionsData = await MgFormQuestion.find({
+        _id: { $in: camp.formQuestions },
+      });
 
-      let campersWithSpecficQuestions: string[] = [];
+      const campersWithSpecficQuestions: string[] = [];
       campers.forEach((camper) => {
-        (camper.formResponses).forEach((value, key) => {
-          const campQuestion = formQuestionsData.find(item => item.question == key);
+        camper.formResponses.forEach((value, key) => {
+          const campQuestion = formQuestionsData.find((item) => item.question == key);
           if (campQuestion?.category === "CampSpecific") {
             campersWithSpecficQuestions.push(camper.id);
           }
@@ -1170,7 +1169,7 @@ class CampService implements ICampService {
 
       return await Promise.all(
         campers.map(async (camper) => {
-            return {
+          return {
               "Registration Date": camper.registrationDate.toLocaleDateString('en-CA').toString(),
               "Camper Name": camper.firstName + ' ' + camper.lastName,
               "Camper Age": camper.age,
@@ -1186,9 +1185,9 @@ class CampService implements ICampService {
               "Amount Paid": camper.charges.camp + camper.charges.earlyDropoff + camper.charges.latePickup,
               "Additional Camp-Specific Q's": (campersWithSpecficQuestions.includes(camper.id)) ? "Y" : "N",
               "Additional Waiver Clauses": (camper.optionalClauses.length > 0) ? "Y" : "N",
-            };
-          }),
-        );
+          };
+        }),
+      );
     } catch (error: unknown) {
       Logger.error(`Failed to get campers. Reason = ${getErrorMessage(error)}`);
       throw error;

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -1145,59 +1145,50 @@ class CampService implements ICampService {
       });
 
       if (!campSession) {
-        throw new Error(`Camp with id ${campSessionId} not found.`);
+        throw new Error(`Camp Session with id ${campSessionId} not found.`);
       }
       const campers = campSession.campers as Camper[];
+      
+      const camp: Camp | null = await MgCamp.findById(campSession.camp);
+      if (!camp) {
+        throw new Error(`Camp with id ${campSessionId} not found.`);
+      }
 
-      const questionIds = new Set(
-        campers.length > 0
-          ? campers.reduce((prevCamper, currCamper) => {
-              return [
-                ...prevCamper,
-                ...Array.from(currCamper.formResponses.keys()),
-              ];
-            }, Array.from(campers[0].formResponses.keys()))
-          : [],
+      let formQuestionsData = await MgFormQuestion.find(
+        {'_id': { $in: camp.formQuestions }}
       );
 
-      const formQuestions = await MgFormQuestion.find({
-        _id: Array.from(questionIds),
-      });
-
-      const formQuestionMap: { [id: string]: string } = {};
-
-      formQuestions.forEach((formQuestion) => {
-        formQuestionMap[formQuestion._id] = formQuestion.question;
+      let campersWithSpecficQuestions: string[] = [];
+      campers.forEach((camper) => {
+        (camper.formResponses).forEach((value, key) => {
+          const campQuestion = formQuestionsData.find(item => item.question == key);
+          if (campQuestion?.category === "CampSpecific") {
+            campersWithSpecficQuestions.push(camper.id);
+          }
+        });
       });
 
       return await Promise.all(
         campers.map(async (camper) => {
-          const { formResponses } = camper;
-          const formResponseObject: { [key: string]: string } = {};
-
-          Array.from(formResponses.keys()).forEach((questionId) => {
-            const question = formQuestionMap[questionId];
-            const answer = formResponses.get(questionId);
-            formResponseObject[question] = answer as string;
-          });
-
-          return {
-            firstName: camper.firstName,
-            lastName: camper.lastName,
-            age: camper.age,
-            allergies: camper.allergies,
-            earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
-            latePickup: camper.latePickup.map((date) => date.toString()),
-            specialNeeds: camper.specialNeeds,
-            contacts: camper.contacts,
-            formResponses: formResponseObject,
-            registrationDate: camper.registrationDate.toString(),
-            hasPaid: camper.hasPaid,
-            chargeId: camper.chargeId,
-            optionalClauses: camper.optionalClauses,
-          };
-        }),
-      );
+            return {
+              "Registration Date": camper.registrationDate.toLocaleDateString('en-CA').toString(),
+              "Camper Name": camper.firstName + ' ' + camper.lastName,
+              "Camper Age": camper.age,
+              "Primary Emergency Contact Name": camper.contacts[0].firstName + ' ' + camper.contacts[0].lastName,
+              "Primary Emergency Contact Phone #": camper.contacts[0].phoneNumber,
+              "Primary Emergency Contact Email": camper.contacts[0].email,
+              "Secondary Emergency Contact Name": (camper.contacts.length > 1) ? camper.contacts[1].firstName + ' ' + camper.contacts[1].lastName : "",
+              "Secondary Emergency Contact Phone #": (camper.contacts.length > 1) ? camper.contacts[1].phoneNumber : "",
+              "Requires Early Drop-off": (camper.earlyDropoff.length > 0) ? "Y" : "N",
+              "Requires Late Pick-up": (camper.earlyDropoff.length > 0) ? "Y" : "N",
+              "Allergies": camper.allergies,
+              "Additional Accomodations": camper.specialNeeds,
+              "Amount Paid": camper.charges.camp + camper.charges.earlyDropoff + camper.charges.latePickup,
+              "Additional Camp-Specific Q's": (campersWithSpecficQuestions.includes(camper.id)) ? "Y" : "N",
+              "Additional Waiver Clauses": (camper.optionalClauses.length > 0) ? "Y" : "N",
+            };
+          }),
+        );
     } catch (error: unknown) {
       Logger.error(`Failed to get campers. Reason = ${getErrorMessage(error)}`);
       throw error;
@@ -1331,26 +1322,12 @@ class CampService implements ICampService {
     try {
       const campers = await this.getCampersByCampSessionId(campSessionId);
       if (campers.length === 0) {
-        // if there are no campers, we return an empty string
+        // if there are no campers, we return an empty string.
         return "";
       }
-      let csvHeaders: string[] = [];
-      const flattenedCampers = campers.map((camper) => {
-        const { formResponses, ...formObj } = camper;
-        // grabbing column names
-        csvHeaders = [
-          ...csvHeaders,
-          ...Object.keys(formResponses),
-          ...Object.keys(formObj),
-        ];
-        return {
-          ...formResponses,
-          ...formObj,
-        };
-      });
-      csvHeaders = Array.from(new Set(csvHeaders));
+      const csvHeaders = Object.keys(campers[0]);
       const csvString = await generateCSV({
-        data: flattenedCampers,
+        data: campers,
         fields: csvHeaders,
       });
       return csvString;

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -64,7 +64,7 @@ interface ICampService {
   ): Promise<Array<CampSessionDTO>>;
 
   /**
-   * Get all campers associated with camps of id campId
+   * Get all campers associated with camp session of id campSessionId
    * @param campSessionId camp's session id
    * @returns array of CamperCSVInfoDTO object containing campers information
    * @throws Error if camper retrieval fails

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -65,11 +65,11 @@ interface ICampService {
 
   /**
    * Get all campers associated with camps of id campId
-   * @param campId camp's id
+   * @param campSessionId camp's session id
    * @returns array of CamperCSVInfoDTO object containing campers information
    * @throws Error if camper retrieval fails
    */
-  getCampersByCampSessionId(campId: string): Promise<CamperCSVInfoDTO[]>;
+  getCampersByCampSessionId(campSessionId: string): Promise<CamperCSVInfoDTO[]>;
 
   /**
    * Generates CSV string containg all the campers associated with a camp

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -64,7 +64,7 @@ interface ICampService {
   ): Promise<Array<CampSessionDTO>>;
 
   /**
-   * Get all campers associated with camp session of id campSessionId
+   * Get all campers associated with camp session of id campSessionId for CSV file generation
    * @param campSessionId camp's session id
    * @returns array of CamperCSVInfoDTO object containing campers information
    * @throws Error if camper retrieval fails

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -82,6 +82,7 @@ export type CamperCSVInfoDTO = {
   "Secondary Emergency Contact Phone #": string;
   "Requires Early Drop-off": string;
   "Requires Late Pick-up": string;
+  // eslint-disable-next-line
   "Allergies": string;
   "Amount Paid": number;
   "Additional Accomodations": string;

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -71,10 +71,23 @@ export type CamperDTO = {
   ];
 };
 
-export type CamperCSVInfoDTO = Omit<
-  CamperDTO,
-  "id" | "campSession" | "charges" | "formResponses"
-> & { formResponses: { [key: string]: string } };
+export type CamperCSVInfoDTO = {
+  "Registration Date": string;
+  "Camper Name": string;
+  "Camper Age": number;
+  "Primary Emergency Contact Name": string;
+  "Primary Emergency Contact Phone #": string;
+  "Primary Emergency Contact Email": string;
+  "Secondary Emergency Contact Name": string;
+  "Secondary Emergency Contact Phone #": string;
+  "Requires Early Drop-off": string;
+  "Requires Late Pick-up": string;
+  "Allergies": string;
+  "Amount Paid": number;
+  "Additional Accomodations": string;
+  "Additional Camp-Specific Q's": string;
+  "Additional Waiver Clauses": string;
+};
 
 export type WaitlistedCamperDTO = {
   id: string;

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -54,7 +54,6 @@ const editCampById = async (
   }
 };
 
-
 const deleteCamp = async (id: string): Promise<boolean> => {
   try {
     await baseAPIClient.delete(`/camp/${id}`, {
@@ -114,7 +113,7 @@ const getCampSessionCsv = async (id: string): Promise<string> => {
   } catch (error) {
     return "ERROR";
   }
-}
+};
 
 export default {
   getAllCamps,

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -54,6 +54,7 @@ const editCampById = async (
   }
 };
 
+
 const deleteCamp = async (id: string): Promise<boolean> => {
   try {
     await baseAPIClient.delete(`/camp/${id}`, {
@@ -104,6 +105,17 @@ const deleteCampSessionsByIds = async (
   }
 };
 
+const getCampSessionCsv = async (id: string): Promise<string> => {
+  try {
+    const { data } = await baseAPIClient.get(`/camp/csv/${id}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as string;
+  }
+}
+
 export default {
   getAllCamps,
   getCampById,
@@ -111,4 +123,5 @@ export default {
   deleteCamp,
   updateCampSessions,
   deleteCampSessionsByIds,
+  getCampSessionCsv,
 };

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -112,7 +112,7 @@ const getCampSessionCsv = async (id: string): Promise<string> => {
     });
     return data;
   } catch (error) {
-    return error as string;
+    return "ERROR";
   }
 }
 

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -38,13 +38,13 @@ import CampsAPIClient from "../../../../APIClients/CampsAPIClient";
 
 import { downloadCSV } from "../../../../utils/CSVUtils";
 
-const ExportButton = ({campSessionId}: {campSessionId: string}): JSX.Element => {
+const ExportButton = ({campSessionId, campSessionCSVFilename}: {campSessionId: string, campSessionCSVFilename: string}): JSX.Element => {
   const toast = useToast();
   
   const generateCsv = async () => {
     const csvResponse = await CampsAPIClient.getCampSessionCsv(campSessionId);
     if (csvResponse !== "ERROR") {
-      downloadCSV(csvResponse, "Campers_Information");
+      downloadCSV(csvResponse, campSessionCSVFilename);
     } else {
       toast({
         description: `An error occurred while exporting the CSV. Please try again.`,
@@ -80,12 +80,14 @@ const CampersTable = ({
   formQuestions,
   handleRefetch,
   campSessionId,
+  campSessionCSVFilename,
 }: {
   campers: Camper[];
   campSessionCapacity: number;
   formQuestions: FormQuestion[];
   handleRefetch: () => void;
   campSessionId: string;
+  campSessionCSVFilename: string;
 }): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
@@ -202,7 +204,7 @@ const CampersTable = ({
                 </Tag>
               );
             })}
-            <ExportButton campSessionId={campSessionId} />
+            <ExportButton campSessionId={campSessionId} campSessionCSVFilename={campSessionCSVFilename}/>
           </HStack>
 
           <Table

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -33,7 +33,16 @@ import ViewCamperModal from "../ViewCamperModal/index";
 import { FormQuestion } from "../../../../types/CampsTypes";
 import RemoveCamperModal from "../RemoveCamperModal/index";
 
-const ExportButton = (): JSX.Element => {
+import CampsAPIClient from "../../../../APIClients/CampsAPIClient";
+
+import { downloadCSV } from "../../../../utils/CSVUtils";
+
+const generateCsv = async (campSessionId: string) => {
+  const csvResponse = await CampsAPIClient.getCampSessionCsv(campSessionId);
+  downloadCSV(csvResponse, "Campers_Information");
+}
+
+const ExportButton = ({campSessionId,}: {campSessionId: string}): JSX.Element => {
   return (
     <Button
       leftIcon={<DownloadIcon />}
@@ -46,6 +55,7 @@ const ExportButton = (): JSX.Element => {
       borderRadius="5px"
       minWidth="-webkit-fit-content"
       fontSize={textStyles.bodyRegular.fontSize}
+      onClick={() => generateCsv(campSessionId)}
     >
       Export as .csv
     </Button>
@@ -57,11 +67,13 @@ const CampersTable = ({
   campSessionCapacity,
   formQuestions,
   handleRefetch,
+  campSessionId,
 }: {
   campers: Camper[];
   campSessionCapacity: number;
   formQuestions: FormQuestion[];
   handleRefetch: () => void;
+  campSessionId: string;
 }): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
@@ -178,7 +190,7 @@ const CampersTable = ({
                 </Tag>
               );
             })}
-            <ExportButton />
+            <ExportButton campSessionId={campSessionId} />
           </HStack>
 
           <Table

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -17,6 +17,7 @@ import {
   Tag,
   Box,
   useDisclosure,
+  useToast,
 } from "@chakra-ui/react";
 import { DownloadIcon, SearchIcon } from "@chakra-ui/icons";
 
@@ -37,12 +38,23 @@ import CampsAPIClient from "../../../../APIClients/CampsAPIClient";
 
 import { downloadCSV } from "../../../../utils/CSVUtils";
 
-const generateCsv = async (campSessionId: string) => {
-  const csvResponse = await CampsAPIClient.getCampSessionCsv(campSessionId);
-  downloadCSV(csvResponse, "Campers_Information");
-}
-
-const ExportButton = ({campSessionId,}: {campSessionId: string}): JSX.Element => {
+const ExportButton = ({campSessionId}: {campSessionId: string}): JSX.Element => {
+  const toast = useToast();
+  
+  const generateCsv = async () => {
+    const csvResponse = await CampsAPIClient.getCampSessionCsv(campSessionId);
+    if (csvResponse !== "ERROR") {
+      downloadCSV(csvResponse, "Campers_Information");
+    } else {
+      toast({
+        description: `An error occurred while exporting the CSV. Please try again.`,
+        status: "error",
+        variant: "subtle",
+        duration: 3000,
+      });
+    }
+  }
+  
   return (
     <Button
       leftIcon={<DownloadIcon />}
@@ -55,7 +67,7 @@ const ExportButton = ({campSessionId,}: {campSessionId: string}): JSX.Element =>
       borderRadius="5px"
       minWidth="-webkit-fit-content"
       fontSize={textStyles.bodyRegular.fontSize}
-      onClick={() => generateCsv(campSessionId)}
+      onClick={() => generateCsv()}
     >
       Export as .csv
     </Button>

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -49,7 +49,7 @@ const ExportButton = ({generateCsv}: {generateCsv: () => void}): JSX.Element => 
         borderRadius="5px"
         minWidth="-webkit-fit-content"
         fontSize={textStyles.bodyRegular.fontSize}
-        onClick={() => generateCsv()}
+        onClick={generateCsv}
       >
         Export as .csv
       </Button>

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -34,43 +34,26 @@ import ViewCamperModal from "../ViewCamperModal/index";
 import { FormQuestion } from "../../../../types/CampsTypes";
 import RemoveCamperModal from "../RemoveCamperModal/index";
 
-import CampsAPIClient from "../../../../APIClients/CampsAPIClient";
-
-import { downloadCSV } from "../../../../utils/CSVUtils";
-
-const ExportButton = ({campSessionId, campSessionCSVFilename}: {campSessionId: string, campSessionCSVFilename: string}): JSX.Element => {
-  const toast = useToast();
-  
-  const generateCsv = async () => {
-    const csvResponse = await CampsAPIClient.getCampSessionCsv(campSessionId);
-    if (csvResponse !== "ERROR") {
-      downloadCSV(csvResponse, campSessionCSVFilename);
-    } else {
-      toast({
-        description: `An error occurred while exporting the CSV. Please try again.`,
-        status: "error",
-        variant: "subtle",
-        duration: 3000,
-      });
-    }
-  }
-  
+const ExportButton = ({generateCsv}: {generateCsv: () => void}): JSX.Element => {  
   return (
-    <Button
-      leftIcon={<DownloadIcon />}
-      aria-label="Export SVG"
-      type="submit"
-      background="background.grey.200"
-      color="primary.green.100"
-      border="2px"
-      borderColor="primary.green.100"
-      borderRadius="5px"
-      minWidth="-webkit-fit-content"
-      fontSize={textStyles.bodyRegular.fontSize}
-      onClick={() => generateCsv()}
-    >
-      Export as .csv
-    </Button>
+    <Box>
+      <Button
+        ml="30px"
+        leftIcon={<DownloadIcon />}
+        aria-label="Export SVG"
+        type="submit"
+        background="background.grey.200"
+        color="primary.green.100"
+        border="2px"
+        borderColor="primary.green.100"
+        borderRadius="5px"
+        minWidth="-webkit-fit-content"
+        fontSize={textStyles.bodyRegular.fontSize}
+        onClick={() => generateCsv()}
+      >
+        Export as .csv
+      </Button>
+    </Box>
   );
 };
 
@@ -79,15 +62,13 @@ const CampersTable = ({
   campSessionCapacity,
   formQuestions,
   handleRefetch,
-  campSessionId,
-  campSessionCSVFilename,
+  generateCsv,
 }: {
   campers: Camper[];
   campSessionCapacity: number;
   formQuestions: FormQuestion[];
   handleRefetch: () => void;
-  campSessionId: string;
-  campSessionCSVFilename: string;
+  generateCsv: () => void;
 }): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
@@ -204,7 +185,7 @@ const CampersTable = ({
                 </Tag>
               );
             })}
-            <ExportButton campSessionId={campSessionId} campSessionCSVFilename={campSessionCSVFilename}/>
+            <ExportButton generateCsv={generateCsv}/>
           </HStack>
 
           <Table

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -5,20 +5,19 @@ import textStyles from "../../../../theme/textStyles";
 import { CampSession, FormQuestion } from "../../../../types/CampsTypes";
 import CampersTable from "./CampersTable";
 import WaitlistedCampersTable from "./WaitlistedCampersTable";
-import { generateCSVName } from "../../../../utils/CSVUtils"
 
 type CampersTablesProps = {
   campSession: CampSession;
   formQuestions: FormQuestion[];
   handleRefetch: () => void;
-  campCity: string;
+  generateCsv: () => void;
 };
 
 const CampersTables = ({
   campSession,
   formQuestions,
   handleRefetch,
-  campCity
+  generateCsv
 }: CampersTablesProps): JSX.Element => {
   return (
     <Box>
@@ -42,8 +41,7 @@ const CampersTables = ({
               formQuestions={formQuestions}
               campSessionCapacity={campSession.capacity}
               handleRefetch={handleRefetch}
-              campSessionId={campSession.id}
-              campSessionCSVFilename={generateCSVName(campCity, campSession.dates[0])}
+              generateCsv={generateCsv}
             />
           </TabPanel>
           <TabPanel padding="0">

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -5,17 +5,20 @@ import textStyles from "../../../../theme/textStyles";
 import { CampSession, FormQuestion } from "../../../../types/CampsTypes";
 import CampersTable from "./CampersTable";
 import WaitlistedCampersTable from "./WaitlistedCampersTable";
+import { generateCSVName } from "../../../../utils/CSVUtils"
 
 type CampersTablesProps = {
   campSession: CampSession;
   formQuestions: FormQuestion[];
   handleRefetch: () => void;
+  campCity: string;
 };
 
 const CampersTables = ({
   campSession,
   formQuestions,
   handleRefetch,
+  campCity
 }: CampersTablesProps): JSX.Element => {
   return (
     <Box>
@@ -40,6 +43,7 @@ const CampersTables = ({
               campSessionCapacity={campSession.capacity}
               handleRefetch={handleRefetch}
               campSessionId={campSession.id}
+              campSessionCSVFilename={generateCSVName(campCity, campSession.dates[0])}
             />
           </TabPanel>
           <TabPanel padding="0">

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -39,6 +39,7 @@ const CampersTables = ({
               formQuestions={formQuestions}
               campSessionCapacity={campSession.capacity}
               handleRefetch={handleRefetch}
+              campSessionId={campSession.id}
             />
           </TabPanel>
           <TabPanel padding="0">

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -22,6 +22,7 @@ import EmptyCampSessionState from "./CampersTable/EmptyCampSessionState";
 import CampersTables from "./CampersTable/CampersTables";
 import * as Routes from "../../../constants/Routes";
 import ManageSessionsModal from "./ManageSessions/ManageSessionsModal";
+import { downloadCSV, generateCSVName } from "../../../utils/CSVUtils";
 
 type ManageSessionsPromisesResult = {
   deletedSessions?: boolean;
@@ -184,6 +185,20 @@ const CampOverviewPage = (): JSX.Element => {
     }
   };
 
+  const generateCsv = async () => {
+    const csvResponse = await CampsAPIClient.getCampSessionCsv(camp.campSessions[currentCampSession].id);
+    if (csvResponse !== "ERROR") {
+      downloadCSV(csvResponse, generateCSVName(camp.location.city, camp.campSessions[currentCampSession].dates[0]));
+    } else {
+      toast({
+        description: `An error occurred while exporting the CSV. Please try again.`,
+        status: "error",
+        variant: "subtle",
+        duration: 3000,
+      });
+    }
+  }
+
   return (
     <Container
       maxWidth="100vw"
@@ -213,7 +228,7 @@ const CampOverviewPage = (): JSX.Element => {
               campSession={camp.campSessions[currentCampSession]}
               formQuestions={camp.formQuestions}
               handleRefetch={handleRefetch}
-              campCity={camp.location.city}
+              generateCsv={generateCsv}
             />
             <ManageSessionsModal
               campStartTime={camp.startTime}

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -213,6 +213,7 @@ const CampOverviewPage = (): JSX.Element => {
               campSession={camp.campSessions[currentCampSession]}
               formQuestions={camp.formQuestions}
               handleRefetch={handleRefetch}
+              campCity={camp.location.city}
             />
             <ManageSessionsModal
               campStartTime={camp.startTime}

--- a/frontend/src/utils/CSVUtils.ts
+++ b/frontend/src/utils/CSVUtils.ts
@@ -82,3 +82,8 @@ export const downloadCSV = (data: string, fileName: string): void => {
     URL.revokeObjectURL(url);
   });
 };
+
+export const generateCSVName = (campCity: string, campSessionDate: string): string => {
+  const startDate = new Date(campSessionDate);
+  return `${campCity}_${startDate.toLocaleString('default', { month: 'short' })}_${startDate.getDay()}_${startDate.getFullYear()}`;
+};

--- a/frontend/src/utils/CSVUtils.ts
+++ b/frontend/src/utils/CSVUtils.ts
@@ -83,6 +83,11 @@ export const downloadCSV = (data: string, fileName: string): void => {
   });
 };
 
+/**
+ * @param campCity name of Camp City (e.g. "Waterloo")
+ * @param campSessionDate camp session start date (e.g. "Thu Jun 30 2022 00:00:00 GMT+0000 (Coordinated Universal Time)")
+ * @return name of the CSV file (e.g. "Waterloo_Jun_3_2022")
+ */
 export const generateCSVName = (campCity: string, campSessionDate: string): string => {
   const startDate = new Date(campSessionDate);
   return `${campCity}_${startDate.toLocaleString('default', { month: 'short' })}_${startDate.getDay()}_${startDate.getFullYear()}`;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Trigger CSV functionality](https://www.notion.so/uwblueprintexecs/Camp-Overview-Trigger-CSV-functionality-86ffe05420a84280a9c8bcec77606dd7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added new function to CampersAPIClients to call backend API for getting CSV string corresponding to camp session ID
* Passed down camp session ID from CampersTable to CamperTable, which is then passed to export CSV button 
* When the export CSV button is clicked, the function in CampersAPIClients is called and the returned CSV string is converted and then downloaded

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/admin/camp/63139c7bc3d7b55b44a01531
2. Click the "export as .csv" button
3. CSV should download and contain content corresponding to the current camp session

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Want to ensure workflow to fetch, convert and download CSV is as efficient as possible

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
