### PR TITLE
feat: add camp overview footer (presentation)

### DIFF
--- a/frontend/src/components/pages/CampOverview/Footer.tsx
+++ b/frontend/src/components/pages/CampOverview/Footer.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Button, ButtonGroup, Flex, Spacer } from "@chakra-ui/react";
+import { CampResponse } from "../../../types/CampsTypes";
+
+type FooterProps = {
+  camp: CampResponse;
+};
+
+const Footer = ({ camp }: FooterProps): JSX.Element => {
+  return (
+    <Flex
+      pos="fixed"
+      bottom="0"
+      width="full"
+      marginLeft="-16px"
+      bg="background.grey.100"
+      padding="16px 40px 16px 40px"
+      boxShadow="xs"
+    >
+      <Button
+        size="sm"
+        bgColor="secondary.critical.100"
+        color="background.white.100"
+        p="16px"
+      >
+        Delete camp
+      </Button>
+      <Spacer />
+      {!camp.active && (
+        <ButtonGroup>
+          <Button
+            size="sm"
+            color="primary.green.100"
+            borderColor="primary.green.100"
+            variant="outline"
+            p="16px"
+          >
+            Edit draft
+          </Button>
+          <Button
+            size="sm"
+            bgColor="primary.green.100"
+            color="background.white.100"
+            p="16px"
+          >
+            Publish camp
+          </Button>
+        </ButtonGroup>
+      )}
+    </Flex>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -6,6 +6,7 @@ import { CampResponse } from "../../../types/CampsTypes";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
 import CampSessionInfoHeader from "../../common/camps/CampSessionInfoHeader";
 import CampDetails from "./CampDetails";
+import Footer from "./Footer";
 import EmptyCampSessionState from "./CampersTable/EmptyCampSessionState";
 import CampersTables from "./CampersTable/CampersTables";
 import * as Routes from "../../../constants/Routes";
@@ -96,6 +97,7 @@ const CampOverviewPage = (): JSX.Element => {
           <EmptyCampSessionState />
         )}
       </Box>
+      <Footer camp={camp} />
     </Container>
   );
 };


### PR DESCRIPTION
* Presentation only - buttons don't work yet

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Footer + Actions](https://www.notion.so/uwblueprintexecs/Camp-Overview-Footer-Actions-9ef2fa77aa924218b4a425ba60d37b43)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added footer to display buttons in Camp Overview


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to unpublished camp, footer should look like this:
<img width="861" alt="Screen Shot 2022-10-04 at 6 47 37 AM" src="https://user-images.githubusercontent.com/41273929/193800815-4860a275-5cff-4e88-af01-0c7879a4f0c9.png">

2. Go to published camp, footer should look like this:
<img width="851" alt="Screen Shot 2022-10-04 at 6 48 26 AM" src="https://user-images.githubusercontent.com/41273929/193800793-2d4ea4fe-f7b9-42ac-8477-fe7e838c0d4f.png">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Just the conditional rendering


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
