### PR TITLE
feat: add camp overview footer (camp deletion)

### DIFF
--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -36,7 +36,19 @@ const editCampById = async (
   }
 };
 
+const deleteCamp = async (id: string): Promise<boolean> => {
+  try {
+    await baseAPIClient.delete(`/camp/${id}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export default {
   getCampById,
   editCampById,
+  deleteCamp,
 };

--- a/frontend/src/components/pages/CampOverview/Footer.tsx
+++ b/frontend/src/components/pages/CampOverview/Footer.tsx
@@ -1,12 +1,21 @@
 import React from "react";
-import { Button, ButtonGroup, Flex, Spacer } from "@chakra-ui/react";
+import {
+  Button,
+  ButtonGroup,
+  Flex,
+  Spacer,
+  useDisclosure,
+} from "@chakra-ui/react";
 import { CampResponse } from "../../../types/CampsTypes";
+import FooterDeleteModal from "./FooterDeleteModal";
 
 type FooterProps = {
   camp: CampResponse;
 };
 
 const Footer = ({ camp }: FooterProps): JSX.Element => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   return (
     <Flex
       pos="fixed"
@@ -22,9 +31,13 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
         bgColor="secondary.critical.100"
         color="background.white.100"
         p="16px"
+        onClick={onOpen}
       >
         Delete camp
       </Button>
+
+      <FooterDeleteModal camp={camp} isOpen={isOpen} onClose={onClose} />
+
       <Spacer />
       {!camp.active && (
         <ButtonGroup>

--- a/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
+++ b/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
@@ -63,7 +63,7 @@ const FooterDeleteModal = ({
             }}
           />
         )}
-        <ModalHeader>{`Delete ${camp.name}`}</ModalHeader>
+        <ModalHeader>Delete {camp.name}</ModalHeader>
         <ModalBody>
           {`Are you sure you want to delete ${camp.name}?`}
           <br />

--- a/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
+++ b/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { Redirect } from "react-router-dom";
+import { CampResponse } from "../../../types/CampsTypes";
+import { CAMPS_PAGE } from "../../../constants/Routes";
+
+import CampsAPIClient from "../../../APIClients/CampsAPIClient";
+
+type FooterDeleteModalProps = {
+  camp: CampResponse;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const FooterDeleteModal = ({
+  camp,
+  isOpen,
+  onClose,
+}: FooterDeleteModalProps): JSX.Element => {
+  const [redirect, setRedirect] = useState<boolean>(false);
+
+  const toast = useToast();
+
+  const handleDeleteCamp = async () => {
+    const res = await CampsAPIClient.deleteCamp(camp.id);
+    if (res) {
+      toast({
+        description: `${camp.name} has been successfully deleted`,
+        status: "success",
+        variant: "subtle",
+        duration: 3000,
+      });
+      setRedirect(true);
+    } else {
+      toast({
+        description: `An error occurred with deleting ${camp.name}`,
+        status: "error",
+        variant: "subtle",
+        duration: 3000,
+      });
+      onClose();
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered preserveScrollBarGap>
+      <ModalOverlay />
+      <ModalContent>
+        {redirect && (
+          <Redirect
+            to={{
+              pathname: CAMPS_PAGE,
+            }}
+          />
+        )}
+        <ModalHeader>{`Delete ${camp.name}`}</ModalHeader>
+        <ModalBody>
+          {`Are you sure you want to delete ${camp.name}?`}
+          <br />
+          <br />
+          <Text as="b">Note: this action is irreversible.</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            size="sm"
+            bgColor="background.grey.100"
+            color="text.default.100"
+            mr={3}
+            p="16px"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            bgColor="secondary.critical.100"
+            color="background.white.100"
+            p="16px"
+            onClick={handleDeleteCamp}
+          >
+            Remove
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default FooterDeleteModal;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Footer + Actions](https://www.notion.so/uwblueprintexecs/Camp-Overview-Footer-Actions-9ef2fa77aa924218b4a425ba60d37b43)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added delete action to camp overview footer


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create new camp
2. Go to camp overview page for said camp and use the delete flow

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I used a state to conditionally render the Redirect - let me know if there's a better way to do that.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
