### PR TITLE
Feat/display registration link

### DIFF
--- a/frontend/src/components/pages/CampOverview/CampDetails.tsx
+++ b/frontend/src/components/pages/CampOverview/CampDetails.tsx
@@ -27,6 +27,7 @@ import {
   CampStatusColor,
 } from "../../../utils/CampUtils";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
+import CampRegistrationLink from "./CampRegistrationLink";
 
 type CampDetailsProps = {
   camp: CampResponse;
@@ -110,6 +111,11 @@ const CampDetails = ({ camp, setCamp }: CampDetailsProps): JSX.Element => {
             </Tag>
           </HStack>
         </HStack>
+        <CampRegistrationLink
+          p={
+            camp.active ? `https://camps.focusonnature.ca/camp/${camp.id}` : ``
+          }
+        />
         <Grid
           templateColumns="repeat(5, 1fr)"
           gap={2}

--- a/frontend/src/components/pages/CampOverview/CampDetails.tsx
+++ b/frontend/src/components/pages/CampOverview/CampDetails.tsx
@@ -112,10 +112,10 @@ const CampDetails = ({ camp, setCamp }: CampDetailsProps): JSX.Element => {
           </HStack>
         </HStack>
         <CampRegistrationLink
-          p={
+          linkUrl={
             camp.active ? `https://camps.focusonnature.ca/camp/${camp.id}` : ``
           }
-          isDisabled={!camp.active}
+          disabled={!camp.active}
         />
         <Grid
           templateColumns="repeat(5, 1fr)"

--- a/frontend/src/components/pages/CampOverview/CampDetails.tsx
+++ b/frontend/src/components/pages/CampOverview/CampDetails.tsx
@@ -115,6 +115,7 @@ const CampDetails = ({ camp, setCamp }: CampDetailsProps): JSX.Element => {
           p={
             camp.active ? `https://camps.focusonnature.ca/camp/${camp.id}` : ``
           }
+          isDisabled={!camp.active}
         />
         <Grid
           templateColumns="repeat(5, 1fr)"

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -7,16 +7,18 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { LinkIcon } from "@chakra-ui/icons";
-import React from "react";
+import React, { useState } from "react";
 
 const CampRegistrationLink = ({
-  p,
-  isDisabled,
+  linkUrl,
+  disabled,
 }: {
-  p: string;
-  isDisabled: boolean;
+  linkUrl: string;
+  disabled: boolean;
 }): JSX.Element => {
   const toast = useToast();
+
+  const [isDisabled, setIsDisabled] = useState(disabled);
 
   return (
     <HStack justifyContent="left" marginBottom="8px">
@@ -24,7 +26,7 @@ const CampRegistrationLink = ({
         <InputLeftElement>
           <LinkIcon color="gray.300" />
         </InputLeftElement>
-        <Input disabled placeholder={p} borderRadius="0" />
+        <Input disabled placeholder={linkUrl} borderRadius="0" />
       </InputGroup>
       <Button
         colorScheme="green"
@@ -32,11 +34,14 @@ const CampRegistrationLink = ({
         size="sm"
         disabled={isDisabled}
         onClick={() => {
-          navigator.clipboard.writeText(p);
+          setIsDisabled(true);
+          setTimeout(() => setIsDisabled(false), 3000);
+          navigator.clipboard.writeText(linkUrl);
           toast({
             title: "Copied to clipboard.",
             status: "success",
             duration: 1500,
+            variant: "subtle",
             isClosable: true,
           });
         }}

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -44,9 +44,8 @@ const CampRegistrationLink = ({
           toast({
             title: "Copied to clipboard.",
             status: "success",
-            duration: 1500,
+            duration: 3000,
             variant: "subtle",
-            isClosable: true,
           });
         }}
       >

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -1,0 +1,44 @@
+import {
+  HStack,
+  Input,
+  Button,
+  InputGroup,
+  InputLeftElement,
+  useToast,
+} from "@chakra-ui/react";
+import { LinkIcon } from "@chakra-ui/icons";
+import React from "react";
+
+const CampRegistrationLink = ({ p }: { p: string }): JSX.Element => {
+  const toast = useToast();
+
+  return (
+    <HStack justifyContent="left" marginBottom="8px">
+      {/* <div></div> */}
+      <InputGroup backgroundColor="white" pointerEvents="none" size="sm">
+        <InputLeftElement>
+          <LinkIcon color="gray.300" />
+        </InputLeftElement>
+        <Input disabled placeholder={p} borderRadius="0" />
+      </InputGroup>
+      <Button
+        colorScheme="green"
+        borderRadius="0"
+        size="sm"
+        onClick={() => {
+          navigator.clipboard.writeText(p);
+          toast({
+            title: "Copied to clipboard.",
+            status: "success",
+            duration: 1500,
+            isClosable: true,
+          });
+        }}
+      >
+        Copy
+      </Button>
+    </HStack>
+  );
+};
+
+export default CampRegistrationLink;

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -9,7 +9,13 @@ import {
 import { LinkIcon } from "@chakra-ui/icons";
 import React from "react";
 
-const CampRegistrationLink = ({ p }: { p: string }): JSX.Element => {
+const CampRegistrationLink = ({
+  p,
+  isDisabled,
+}: {
+  p: string;
+  isDisabled: boolean;
+}): JSX.Element => {
   const toast = useToast();
 
   return (
@@ -25,6 +31,7 @@ const CampRegistrationLink = ({ p }: { p: string }): JSX.Element => {
         colorScheme="green"
         borderRadius="0"
         size="sm"
+        disabled={isDisabled}
         onClick={() => {
           navigator.clipboard.writeText(p);
           toast({

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -20,7 +20,6 @@ const CampRegistrationLink = ({
 
   return (
     <HStack justifyContent="left" marginBottom="8px">
-      {/* <div></div> */}
       <InputGroup backgroundColor="white" pointerEvents="none" size="sm">
         <InputLeftElement>
           <LinkIcon color="gray.300" />

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -7,7 +7,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { LinkIcon } from "@chakra-ui/icons";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 const CampRegistrationLink = ({
   linkUrl,
@@ -18,7 +18,11 @@ const CampRegistrationLink = ({
 }): JSX.Element => {
   const toast = useToast();
 
-  const [isDisabled, setIsDisabled] = useState(disabled);
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    setIsDisabled(disabled);
+  }, [disabled]);
 
   return (
     <HStack justifyContent="left" marginBottom="8px">


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Display registration link on top half + Copy interaction](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=9ee07dc64a114a048f3d9e3cec204dcc&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Built a component that displays the registration link in a disabled input field
* Added a button that copies the link to clipboard, displaying a toast

![image](https://user-images.githubusercontent.com/31112327/194215319-784b3210-cd17-40ba-a573-5c48bcfed272.png)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to a camp (i.e. http://localhost:3000/admin/camp/63139c7bc3d7b55b44a01531)
2. Copy the registration link
3. Test an inactive camp to see that the link is empty, button is disabled


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Behaviour for active/inactive camps, hardcoding for the link


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
