### PR TITLE
Create bulk update camp sessions endpoint

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -342,13 +342,19 @@ export const updateCampSessionDtoValidator = async (
   next: NextFunction,
 ) => {
   const campSession = req.body;
+  if (!campSession.dates && !campSession.capacity) {
+    return res.status(400).send("no fields to update included in request body");
+  }
   if (campSession.dates && !validateArray(campSession.dates, "string")) {
     return res.status(400).send(getApiValidationError("dates", "string", true));
   }
   if (campSession.dates && !campSession.dates.every(validateDate)) {
     return res.status(400).send(getApiValidationError("dates", "Date string"));
   }
-  if (!validatePrimitive(campSession.capacity, "integer")) {
+  if (
+    campSession.capacity &&
+    !validatePrimitive(campSession.capacity, "integer")
+  ) {
     return res.status(400).send(getApiValidationError("capacity", "integer"));
   }
   if (req.body.campers) {

--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -387,37 +387,22 @@ export const updateCampSessionsDtoValidator = async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (req.body.campers) {
-    return res
-      .status(400)
-      .send("cannot directly edit campers, field should be empty");
-  }
-  if (req.body.waitlist) {
-    return res
-      .status(400)
-      .send("cannot directly edit waitlist, field should be empty");
-  }
-
-  const { campSessionIds } = req.body;
-  if (!campSessionIds) {
-    return res.status(400).send("campSessionIds are required");
-  }
-
-  for (let index = 0; index < campSessionIds.length; index += 1) {
-    const id = campSessionIds[index];
-    if (!validatePrimitive(id, "string")) {
-      return res.status(400).send(getApiValidationError("id", "string"));
-    }
-  }
-
   const campSessions = req.body.updatedCampSessions;
 
   if (!campSessions) {
-    return res.status(400).send("campSessions are required");
+    return res.status(400).send("updatedCampSessions is a required field");
   }
 
   for (let index = 0; index < campSessions.length; index += 1) {
     const campSession = campSessions[index];
+    if (!campSession.id) {
+      return res
+        .status(400)
+        .send("id is a required field for all camp sessions");
+    }
+    if (!validatePrimitive(campSession.id, "string")) {
+      return res.status(400).send(getApiValidationError("id", "string"));
+    }
     if (campSession.dates && !validateArray(campSession.dates, "string")) {
       return res
         .status(400)
@@ -430,6 +415,16 @@ export const updateCampSessionsDtoValidator = async (
     }
     if (!validatePrimitive(campSession.capacity, "integer")) {
       return res.status(400).send(getApiValidationError("capacity", "integer"));
+    }
+    if (campSession.campers) {
+      return res
+        .status(400)
+        .send("cannot directly edit campers, remove field on request object");
+    }
+    if (campSession.waitlist) {
+      return res
+        .status(400)
+        .send("cannot directly edit waitlist, remove field on request object");
     }
   }
   return next();

--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -360,6 +360,7 @@ export const updateCampSessionDtoValidator = async (
   return next();
 };
 
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable-next-line import/prefer-default-export */
 export const deleteCampSessionsDtoValidator = async (
   req: Request,
@@ -375,6 +376,61 @@ export const deleteCampSessionsDtoValidator = async (
     }
   } else {
     return res.status(400).send("campSessionIds does not exist");
+  }
+  return next();
+};
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable-next-line import/prefer-default-export */
+export const updateCampSessionsDtoValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.body.campers) {
+    return res
+      .status(400)
+      .send("cannot directly edit campers, field should be empty");
+  }
+  if (req.body.waitlist) {
+    return res
+      .status(400)
+      .send("cannot directly edit waitlist, field should be empty");
+  }
+
+  const { campSessionIds } = req.body;
+  if (!campSessionIds) {
+    return res.status(400).send("campSessionIds are required");
+  }
+
+  for (let index = 0; index < campSessionIds.length; index += 1) {
+    const id = campSessionIds[index];
+    if (!validatePrimitive(id, "string")) {
+      return res.status(400).send(getApiValidationError("id", "string"));
+    }
+  }
+
+  const campSessions = req.body.updatedCampSessions;
+
+  if (!campSessions) {
+    return res.status(400).send("campSessions are required");
+  }
+
+  for (let index = 0; index < campSessions.length; index += 1) {
+    const campSession = campSessions[index];
+    if (campSession.dates && !validateArray(campSession.dates, "string")) {
+      return res
+        .status(400)
+        .send(getApiValidationError("dates", "string", true));
+    }
+    if (campSession.dates && !campSession.dates.every(validateDate)) {
+      return res
+        .status(400)
+        .send(getApiValidationError("dates", "Date string"));
+    }
+    if (!validatePrimitive(campSession.capacity, "integer")) {
+      return res.status(400).send(getApiValidationError("capacity", "integer"));
+    }
   }
   return next();
 };

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -182,6 +182,24 @@ campRouter.patch(
   },
 );
 
+/* Update camp sessions */
+campRouter.patch(
+  "/:campId/session/",
+  updateCampSessionDtoValidator,
+  async (req, res) => {
+    try {
+      const campSession = await campService.updateCampSessionsByIds(
+        req.params.campId,
+        req.body.campSessionIds,
+        req.body.updatedCampSessions,
+      );
+      res.status(200).json(campSession);
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  },
+);
+
 /* Delete a camp session */
 campRouter.delete("/:campId/session/:campSessionId", async (req, res) => {
   try {

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -14,6 +14,7 @@ import {
   editFormQuestionValidator,
   updateCampDtoValidator,
   updateCampSessionDtoValidator,
+  updateCampSessionsDtoValidator,
 } from "../middlewares/validators/campValidators";
 
 const upload = multer({ dest: "uploads/" });
@@ -185,12 +186,11 @@ campRouter.patch(
 /* Update camp sessions */
 campRouter.patch(
   "/:campId/session/",
-  updateCampSessionDtoValidator,
+  updateCampSessionsDtoValidator,
   async (req, res) => {
     try {
       const campSession = await campService.updateCampSessionsByIds(
         req.params.campId,
-        req.body.campSessionIds,
         req.body.updatedCampSessions,
       );
       res.status(200).json(campSession);

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -258,7 +258,7 @@ describe("mongo campService", (): void => {
 
     expect(campSession?.camp.toString()).toEqual(res.id);
     expect(campSession?.dates.map((date) => new Date(date))).toEqual(
-      updatedTestCampSession.dates.map((date) => new Date(date)),
+      updatedTestCampSession.dates?.map((date) => new Date(date)),
     );
     expect(campSession?.capacity).toEqual(updatedTestCampSession.capacity);
     expect(campSession?.campers).toHaveLength(0);

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -741,14 +741,18 @@ class CampService implements ICampService {
         );
         if (oldCampSession) {
           if (
-            oldCampSession.campers !== null &&
+            oldCampSession.campers &&
+            campSession.capacity &&
             campSession.capacity < oldCampSession.campers.length
           ) {
             throw new Error(
               `Cannot decrease capacity to current number of registered campers. Requested capacity change: ${campSession.capacity}, current number of registed campers: ${oldCampSession.campers.length}`,
             );
           }
-          if (oldCampSession.dates.length !== campSession.dates.length) {
+          if (
+            campSession.dates &&
+            oldCampSession.dates.length !== campSession.dates.length
+          ) {
             throw new Error(
               `Cannot change the number of dates for an active camp. Requested dates length: ${campSession.dates.length}, current number of dates ${oldCampSession.dates.length}`,
             );
@@ -763,8 +767,13 @@ class CampService implements ICampService {
       const newCampSession: CampSession | null = await MgCampSession.findByIdAndUpdate(
         campSessionId,
         {
-          capacity: campSession.capacity,
-          dates: campSession.dates ? campSession.dates.sort() : undefined,
+          ...(campSession.capacity && { capacity: campSession.capacity }),
+          ...(campSession.dates && {
+            dates: campSession.dates.sort(
+              (dateA, dateB) =>
+                new Date(dateA).getTime() - new Date(dateB).getTime(),
+            ),
+          }),
         },
         { runValidators: true, new: true },
       );

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -8,6 +8,7 @@ import {
   UpdateCampDTO,
   CreateCampSessionsDTO,
   FormQuestionDTO,
+  UpdateCampSessionsDTO,
 } from "../../types";
 
 interface ICampService {
@@ -59,8 +60,7 @@ interface ICampService {
 
   updateCampSessionsByIds(
     campId: string,
-    campSessionIds: Array<string>,
-    updatedCampSessions: Array<UpdateCampSessionDTO>,
+    updatedCampSessions: Array<UpdateCampSessionsDTO>,
   ): Promise<Array<CampSessionDTO>>;
 
   /**

--- a/backend/typescript/services/interfaces/campService.ts
+++ b/backend/typescript/services/interfaces/campService.ts
@@ -57,6 +57,12 @@ interface ICampService {
     campSession: UpdateCampSessionDTO,
   ): Promise<CampSessionDTO>;
 
+  updateCampSessionsByIds(
+    campId: string,
+    campSessionIds: Array<string>,
+    updatedCampSessions: Array<UpdateCampSessionDTO>,
+  ): Promise<Array<CampSessionDTO>>;
+
   /**
    * Get all campers associated with camps of id campId
    * @param campId camp's id

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -187,10 +187,9 @@ export type UpdateCampSessionDTO = Omit<
   "id" | "camp" | "campers" | "waitlist" | "campPriceId"
 >;
 
-export type UpdateCampSessionsDTO = Omit<
-  CampSessionDTO,
-  "camp" | "campers" | "waitlist" | "campPriceId"
->;
+export type UpdateCampSessionsDTO = Partial<
+  Omit<CampSessionDTO, "camp" | "campers" | "waitlist" | "campPriceId">
+> & { id: string };
 
 export type CreateFormQuestionsDTO = Omit<FormQuestionDTO, "id">[];
 

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -177,14 +177,9 @@ export type CreateCampSessionsDTO = Array<
   Omit<CampSessionDTO, "id" | "camp" | "campers" | "waitlist" | "campPriceId">
 >;
 
-// export type CampSessionDTO = {
-//   capacity: number;
-//   dates: string[];
-// };
-
-export type UpdateCampSessionDTO = Omit<
-  CampSessionDTO,
-  "id" | "camp" | "campers" | "waitlist" | "campPriceId"
+// Exposes "dates: string[]" and "capacity: number"
+export type UpdateCampSessionDTO = Partial<
+  Omit<CampSessionDTO, "id" | "camp" | "campers" | "waitlist" | "campPriceId">
 >;
 
 export type UpdateCampSessionsDTO = Partial<

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -187,6 +187,11 @@ export type UpdateCampSessionDTO = Omit<
   "id" | "camp" | "campers" | "waitlist" | "campPriceId"
 >;
 
+export type UpdateCampSessionsDTO = Omit<
+  CampSessionDTO,
+  "camp" | "campers" | "waitlist" | "campPriceId"
+>;
+
 export type CreateFormQuestionsDTO = Omit<FormQuestionDTO, "id">[];
 
 export type UpdateFormQuestionDTO = Omit<FormQuestionDTO, "id">[];


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Delete Session + Change Session Capacity ](https://www.notion.so/uwblueprintexecs/Camp-Overview-Delete-Session-Change-Session-Capacity-6d18cb517d61447ab691f8a7d37978f6)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Create bulk update at `PATCH /camp/:camp_id/session`
* Change update endpoint at `PATCH /camp/:camp_id/session/:session_id` to not make capacity and dates both mandatory


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test

`PATCH /camp/63538bc01bf0453b8a55ea1a/session`

- tested malformed inputs (invalid primitives, non-array body)
- tested happy path, all / partial fields (example body has both)
- tested invalid id, id does not exist cases

```json
{
  "updatedCampSessions": [
    {
      "id": "6353a97ff9b07c73611423ed",
      "capacity": 22
    },
    {
      "id": "6353b23dbd2327c976b7ee6a",
      "capacity": 23, 
      "dates": [
        "Mon Mar 14 2022 12:00:00 GMT+0000 (Coordinated Universal Time)",
        "Wed Mar 16 2022 12:00:00 GMT+0000 (Coordinated Universal Time)",
        "Fri Mar 18 2022 12:00:00 GMT+0000 (Coordinated Universal Time)"
      ]
    }
  ]
}
```

`PATCH /camp/63538bc01bf0453b8a55ea1a/session/6353a97ff9b07c73611423ed`

- test partial bodies, eg.
```json
{
  "capacity": 25,
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Check use of transactions
* Check optional field logic, does this make sense from a product standpoint?
* There's no objectId validation in campValidator? Do we want it (cast will fail at some point otherwise anyways, but a worse pattern)?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
