### PR TITLE
Connect Manage Sessions modal to API Client

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -408,7 +408,12 @@ export const updateCampSessionsDtoValidator = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const campSessions = req.body.updatedCampSessions;
+  const body = req.body.data;
+  if (!body) {
+    return res.status(400).send("no data found in request body");
+  }
+
+  const campSessions = body.updatedCampSessions;
 
   if (!campSessions) {
     return res.status(400).send("updatedCampSessions is a required field");

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -193,7 +193,7 @@ campRouter.patch(
     try {
       const campSession = await campService.updateCampSessionsByIds(
         req.params.campId,
-        req.body.updatedCampSessions,
+        req.body.data.updatedCampSessions,
       );
       res.status(200).json(campSession);
     } catch (error: unknown) {

--- a/backend/typescript/services/implementations/__tests__/campService.test.ts
+++ b/backend/typescript/services/implementations/__tests__/campService.test.ts
@@ -3,14 +3,11 @@ import CampService from "../campService";
 import {
   CreateCampDTO,
   CreateCampSessionsDTO,
-  CreateFormQuestionsDTO,
   UpdateCampSessionDTO,
   UpdateCampDTO,
-  CampDTO,
 } from "../../../types";
 import MgCampSession from "../../../models/campSession.model";
 import MgCamp from "../../../models/camp.model";
-import MgFormQuestion from "../../../models/formQuestion.model";
 import FileStorageService from "../fileStorageService";
 import IFileStorageService from "../../interfaces/fileStorageService";
 

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -1,5 +1,5 @@
 import { BEARER_TOKEN } from "../constants/AuthConstants";
-import { CampResponse } from "../types/CampsTypes";
+import { CampResponse, UpdateCampSessionsRequest } from "../types/CampsTypes";
 import baseAPIClient from "./BaseAPIClient";
 
 const getCampById = async (id: string): Promise<CampResponse> => {
@@ -47,8 +47,60 @@ const deleteCamp = async (id: string): Promise<boolean> => {
   }
 };
 
+const updateCampSessions = async (
+  campId: string,
+  campSessionIds: Array<string>,
+  updatedCampSessions: Array<UpdateCampSessionsRequest>,
+): Promise<Array<CampResponse>> => {
+  try {
+    const formData = new FormData();
+    formData.append(
+      "data",
+      JSON.stringify({
+        campSessionIds,
+        updatedCampSessions,
+      }),
+    );
+
+    const { data } = await baseAPIClient.patch(
+      `/camp/${campId}/session`,
+      formData,
+      {
+        headers: {
+          Authorization: BEARER_TOKEN,
+        },
+      },
+    );
+
+    return data;
+  } catch (error) {
+    return error as Array<CampResponse>;
+  }
+};
+
+const deleteCampSessionsByIds = async (
+  campId: string,
+  campSessionIds: Array<string>,
+): Promise<boolean> => {
+  try {
+    await baseAPIClient.delete(`/camp/${campId}/session`, {
+      headers: {
+        Authorization: BEARER_TOKEN,
+      },
+      data: {
+        campSessionIds,
+      },
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export default {
   getCampById,
   editCampById,
   deleteCamp,
+  updateCampSessions,
+  deleteCampSessionsByIds,
 };

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -1,5 +1,9 @@
 import { BEARER_TOKEN } from "../constants/AuthConstants";
-import { CampResponse, UpdateCampSessionsRequest } from "../types/CampsTypes";
+import {
+  CampResponse,
+  CampSessionResponse,
+  UpdateCampSessionsRequest,
+} from "../types/CampsTypes";
 import baseAPIClient from "./BaseAPIClient";
 
 const getCampById = async (id: string): Promise<CampResponse> => {
@@ -49,32 +53,21 @@ const deleteCamp = async (id: string): Promise<boolean> => {
 
 const updateCampSessions = async (
   campId: string,
-  campSessionIds: Array<string>,
   updatedCampSessions: Array<UpdateCampSessionsRequest>,
-): Promise<Array<CampResponse>> => {
+): Promise<Array<CampSessionResponse>> => {
   try {
-    const formData = new FormData();
-    formData.append(
-      "data",
-      JSON.stringify({
-        campSessionIds,
-        updatedCampSessions,
-      }),
-    );
-
-    const { data } = await baseAPIClient.patch(
-      `/camp/${campId}/session`,
-      formData,
-      {
-        headers: {
-          Authorization: BEARER_TOKEN,
-        },
+    const { data } = await baseAPIClient.patch(`/camp/${campId}/session`, {
+      headers: {
+        Authorization: BEARER_TOKEN,
       },
-    );
+      data: {
+        updatedCampSessions,
+      },
+    });
 
     return data;
   } catch (error) {
-    return error as Array<CampResponse>;
+    return error as Array<CampSessionResponse>;
   }
 };
 

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -56,10 +56,13 @@ const CampOverviewPage = (): JSX.Element => {
     volunteers: "",
     campPhotoUrl: "",
   });
-  const [sessionsDidChange, setSessionsDidChange] = useState(false);
   const numSessions = camp.campSessions?.length;
 
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isOpenManageSessionsModal,
+    onOpen: onOpenManageSessionsModal,
+    onClose: onCloseManageSessionsModal,
+  } = useDisclosure();
   const toast = useToast();
 
   const [refetch, setRefetch] = useState<boolean>(true);
@@ -76,7 +79,7 @@ const CampOverviewPage = (): JSX.Element => {
     };
 
     getCamp();
-  }, [campId, refetch, sessionsDidChange]);
+  }, [campId, refetch]);
 
   const onNextSession = () => {
     if (numSessions >= 2)
@@ -92,8 +95,6 @@ const CampOverviewPage = (): JSX.Element => {
       );
   };
 
-  const openManageSessionsModal = () => onOpen();
-
   const getUpdateCampSessionsRequestArray = (
     updatedCapacities: Map<string, string>,
   ): Array<UpdateCampSessionsRequest> => {
@@ -104,6 +105,8 @@ const CampOverviewPage = (): JSX.Element => {
       if (updatedCapacityExists) {
         requests.push({ id, capacity: parseInt(capacity, 10) });
       }
+
+      console.log(requests);
     });
 
     return requests;
@@ -165,7 +168,7 @@ const CampOverviewPage = (): JSX.Element => {
 
     if (!requestFailed) {
       setTimeout(() => {
-        setSessionsDidChange(true);
+        handleRefetch();
         setCurrentCampSession(0);
       }, 500);
 
@@ -206,7 +209,7 @@ const CampOverviewPage = (): JSX.Element => {
               currentCampSession={currentCampSession}
               onNextSession={onNextSession}
               onPrevSession={onPrevSession}
-              onClickManageSessions={openManageSessionsModal}
+              onClickManageSessions={onOpenManageSessionsModal}
             />
             <CampersTables
               campSession={camp.campSessions[currentCampSession]}
@@ -230,8 +233,8 @@ const CampOverviewPage = (): JSX.Element => {
                   };
                 })}
               onSaveChanges={onManageSessionsSave}
-              isOpen={isOpen}
-              onClose={onClose}
+              isOpen={isOpenManageSessionsModal}
+              onClose={onCloseManageSessionsModal}
             />
           </>
         ) : (

--- a/frontend/src/types/CampsTypes.ts
+++ b/frontend/src/types/CampsTypes.ts
@@ -46,6 +46,8 @@ export type CampSession = {
   dates: string[];
 };
 
+export type CampSessionResponse = CampSession & { campPriceId: string };
+
 export type ManageCampSessionDetails = Omit<
   CampSession,
   "camp" | "campers" | "waitlist"

--- a/frontend/src/types/CampsTypes.ts
+++ b/frontend/src/types/CampsTypes.ts
@@ -51,6 +51,12 @@ export type ManageCampSessionDetails = Omit<
   "camp" | "campers" | "waitlist"
 > & { registeredCampers: number };
 
+// { id: string; capacity?: number; dates?: string[] }
+export type UpdateCampSessionsRequest = Partial<
+  Omit<CampSession, "camp" | "campers" | "waitlist">
+> &
+  Pick<CampSession, "id">;
+
 export type FormQuestion = {
   id: string;
   type: QuestionType;


### PR DESCRIPTION
## Notion ticket link
[Camp Overview: Delete Session Change, Change Session Capacity](https://www.notion.so/uwblueprintexecs/Camp-Overview-Delete-Session-Change-Session-Capacity-6d18cb517d61447ab691f8a7d37978f6)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description


Outstanding pieces of UX work
- [ ] Save disabled if invalid input (debounce?)
- [ ] Tooltip explaining why state invalid

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create sessions if needed
2. End to end flow testable -> Open "Manage Sessions" Modal, delete and/or edit capacities
3. Check that modal closes, state updates as expected. If you re-open the modal, your changes should be as expected


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Check comments on PR


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
