### PR TITLE
Camp Overview: Remove Camper(s) from session

### DIFF
--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -87,7 +87,8 @@ camperRouter.get("/refund-confirm/:chargeId", async (req, res) => {
   }
 });
 
-camperRouter.get("/campers-removal/:chargeId/:sessionId", async (req, res) => {
+/* Get campers that have the specified charge ID and session ID */
+camperRouter.get("/:chargeId/:sessionId", async (req, res) => {
   const { chargeId, sessionId } = req.params;
   try {
     const camper = await camperService.getCampersByChargeIdAndSessionId(

--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -87,6 +87,19 @@ camperRouter.get("/refund-confirm/:chargeId", async (req, res) => {
   }
 });
 
+camperRouter.get("/campers-removal/:chargeId/:sessionId", async (req, res) => {
+  const { chargeId, sessionId } = req.params;
+  try {
+    const camper = await camperService.getCampersByChargeIdAndSessionId(
+      (chargeId as unknown) as string,
+      (sessionId as unknown) as string,
+    );
+    res.status(200).json(camper);
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
 camperRouter.post(
   "/waitlist",
   createWaitlistedCamperDtoValidator,
@@ -172,7 +185,7 @@ camperRouter.delete(
   },
 );
 
-/* Delete a camper */
+/* Delete campers (single or multiple) */
 camperRouter.delete("/", deleteCamperDtoValidator, async (req, res) => {
   try {
     await camperService.deleteCampersById(req.body.camperIds);

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -308,13 +308,18 @@ class CamperService implements ICamperService {
     }
   }
 
-  async getCampersByChargeIdAndSessionId(chargeId: string, sessionId: string): Promise<CamperDTO[]> {
+  async getCampersByChargeIdAndSessionId(
+    chargeId: string,
+    sessionId: string,
+  ): Promise<CamperDTO[]> {
     try {
       // eslint-disable-next-line prettier/prettier
       const campers: Camper[] = await MgCamper.find({ chargeId, campSession: sessionId });
 
       if (!campers || campers.length === 0) {
-        throw new Error(`Campers with Charge Id ${chargeId} and Session Id ${sessionId} not found.`);
+        throw new Error(
+          `Campers with Charge Id ${chargeId} and Session Id ${sessionId} not found.`,
+        );
       }
 
       const camperDTO: CamperDTO[] = campers.map((camper) => {

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -308,6 +308,43 @@ class CamperService implements ICamperService {
     }
   }
 
+  async getCampersByChargeIdAndSessionId(chargeId: string, sessionId: string): Promise<CamperDTO[]> {
+    try {
+      // eslint-disable-next-line prettier/prettier
+      const campers: Camper[] = await MgCamper.find({ chargeId, campSession: sessionId });
+
+      if (!campers || campers.length === 0) {
+        throw new Error(`Campers with Charge Id ${chargeId} and Session Id ${sessionId} not found.`);
+      }
+
+      const camperDTO: CamperDTO[] = campers.map((camper) => {
+        return {
+          id: camper.id,
+          campSession: camper.campSession ? camper.campSession.toString() : "",
+          firstName: camper.firstName,
+          lastName: camper.lastName,
+          age: camper.age,
+          allergies: camper.allergies,
+          earlyDropoff: camper.earlyDropoff.map((date) => date.toString()),
+          latePickup: camper.latePickup.map((date) => date.toString()),
+          specialNeeds: camper.specialNeeds,
+          contacts: camper.contacts,
+          formResponses: camper.formResponses,
+          registrationDate: camper.registrationDate.toString(),
+          hasPaid: camper.hasPaid,
+          chargeId: camper.chargeId,
+          charges: camper.charges,
+          optionalClauses: camper.optionalClauses,
+        };
+      });
+
+      return camperDTO;
+    } catch (error: unknown) {
+      Logger.error(`Failed to get campers. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
   async createWaitlistedCamper(
     waitlistedCamper: CreateWaitlistedCamperDTO,
   ): Promise<WaitlistedCamperDTO> {

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -42,10 +42,19 @@ interface ICamperService {
   /**
    * Get campers associated with charge id
    * @param chargeId camper's charge id for refunds
-   * @returns CamperDTO
+   * @returns array of CamperDTO
    * @throws Error if camper retrieval fails
    */
   getCampersByChargeId(chargeId: string): Promise<Array<CamperDTO>>;
+
+  /**
+   * Get campers associated with charge id and session id
+   * @param chargeId camper's charge id indicating which other campers they were registered with
+   * @param sessionId camper's session id indicating what camp session they're registered in
+   * @returns array of CamperDTO
+   * @throws Error if camper retrieval fails
+   */
+   getCampersByChargeIdAndSessionId(chargeId: string, sessionId: string): Promise<Array<CamperDTO>>;
 
   /**
    * Create a waitlisted camper

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -54,7 +54,10 @@ interface ICamperService {
    * @returns array of CamperDTO
    * @throws Error if camper retrieval fails
    */
-   getCampersByChargeIdAndSessionId(chargeId: string, sessionId: string): Promise<Array<CamperDTO>>;
+  getCampersByChargeIdAndSessionId(
+    chargeId: string,
+    sessionId: string,
+  ): Promise<Array<CamperDTO>>;
 
   /**
    * Create a waitlisted camper

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -68,7 +68,7 @@ const getCampersByChargeIdAndSessionId = async (
 ): Promise<Camper[]> => {
   try {
     const { data } = await baseAPIClient.get(
-      `/campers/campers-removal/${chargeId}/${sessionId}`,
+      `/campers/${chargeId}/${sessionId}`,
       {
         headers: { Authorization: BEARER_TOKEN },
       },

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -2,6 +2,7 @@ import { BEARER_TOKEN } from "../constants/AuthConstants";
 import {
   WaitlistedCamper,
   UpdateWaitlistedStatusType,
+  Camper,
 } from "../types/CamperTypes";
 import baseAPIClient from "./BaseAPIClient";
 
@@ -47,8 +48,35 @@ const deleteWaitlistedCamperById = async (id: string): Promise<boolean> => {
   }
 };
 
+const deleteMultipleCampersById = async (ids: string[]): Promise<boolean> => {
+  try {
+    await baseAPIClient.delete(`/campers/`, {
+      headers: { Authorization: BEARER_TOKEN },
+      data: {
+        camperIds: ids
+      }
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const getCampersByChargeIdAndSessionId = async (chargeId: string, sessionId: string): Promise<Camper[]> => {
+  try {
+    const { data } = await baseAPIClient.get(`/campers/campers-removal/${chargeId}/${sessionId}`, {
+      headers: { Authorization: BEARER_TOKEN },
+    });
+    return data;
+  } catch (error) {
+    return error as Camper[];
+  }
+}
+
 export default {
   getWaitlistedCamperById,
   updateCamperRegistrationStatus,
   deleteWaitlistedCamperById,
+  getCampersByChargeIdAndSessionId,
+  deleteMultipleCampersById,
 };

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -53,8 +53,8 @@ const deleteMultipleCampersById = async (ids: string[]): Promise<boolean> => {
     await baseAPIClient.delete(`/campers/`, {
       headers: { Authorization: BEARER_TOKEN },
       data: {
-        camperIds: ids
-      }
+        camperIds: ids,
+      },
     });
     return true;
   } catch (error) {
@@ -62,16 +62,22 @@ const deleteMultipleCampersById = async (ids: string[]): Promise<boolean> => {
   }
 };
 
-const getCampersByChargeIdAndSessionId = async (chargeId: string, sessionId: string): Promise<Camper[]> => {
+const getCampersByChargeIdAndSessionId = async (
+  chargeId: string,
+  sessionId: string,
+): Promise<Camper[]> => {
   try {
-    const { data } = await baseAPIClient.get(`/campers/campers-removal/${chargeId}/${sessionId}`, {
-      headers: { Authorization: BEARER_TOKEN },
-    });
+    const { data } = await baseAPIClient.get(
+      `/campers/campers-removal/${chargeId}/${sessionId}`,
+      {
+        headers: { Authorization: BEARER_TOKEN },
+      },
+    );
     return data;
   } catch (error) {
     return error as Camper[];
   }
-}
+};
 
 export default {
   getWaitlistedCamperById,

--- a/frontend/src/components/pages/CampOverview/CampDetails.tsx
+++ b/frontend/src/components/pages/CampOverview/CampDetails.tsx
@@ -27,6 +27,7 @@ import {
   CampStatusColor,
 } from "../../../utils/CampUtils";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
+import CampRegistrationLink from "./CampRegistrationLink";
 
 type CampDetailsProps = {
   camp: CampResponse;
@@ -110,6 +111,12 @@ const CampDetails = ({ camp, setCamp }: CampDetailsProps): JSX.Element => {
             </Tag>
           </HStack>
         </HStack>
+        <CampRegistrationLink
+          linkUrl={
+            camp.active ? `https://camps.focusonnature.ca/camp/${camp.id}` : ``
+          }
+          disabled={!camp.active}
+        />
         <Grid
           templateColumns="repeat(5, 1fr)"
           gap={2}

--- a/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
+++ b/frontend/src/components/pages/CampOverview/CampRegistrationLink.tsx
@@ -1,0 +1,58 @@
+import {
+  HStack,
+  Input,
+  Button,
+  InputGroup,
+  InputLeftElement,
+  useToast,
+} from "@chakra-ui/react";
+import { LinkIcon } from "@chakra-ui/icons";
+import React, { useState, useEffect } from "react";
+
+const CampRegistrationLink = ({
+  linkUrl,
+  disabled,
+}: {
+  linkUrl: string;
+  disabled: boolean;
+}): JSX.Element => {
+  const toast = useToast();
+
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    setIsDisabled(disabled);
+  }, [disabled]);
+
+  return (
+    <HStack justifyContent="left" marginBottom="8px">
+      <InputGroup backgroundColor="white" pointerEvents="none" size="sm">
+        <InputLeftElement>
+          <LinkIcon color="gray.300" />
+        </InputLeftElement>
+        <Input disabled placeholder={linkUrl} borderRadius="0" />
+      </InputGroup>
+      <Button
+        colorScheme="green"
+        borderRadius="0"
+        size="sm"
+        disabled={isDisabled}
+        onClick={() => {
+          setIsDisabled(true);
+          setTimeout(() => setIsDisabled(false), 3000);
+          navigator.clipboard.writeText(linkUrl);
+          toast({
+            title: "Copied to clipboard.",
+            status: "success",
+            duration: 3000,
+            variant: "subtle",
+          });
+        }}
+      >
+        Copy
+      </Button>
+    </HStack>
+  );
+};
+
+export default CampRegistrationLink;

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -54,9 +54,11 @@ const ExportButton = (): JSX.Element => {
 const CampersTable = ({
   campers,
   campSessionCapacity,
+  handleRefetch,
 }: {
   campers: Camper[];
   campSessionCapacity: number;
+  handleRefetch: () => void;
 }): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
@@ -281,6 +283,7 @@ const CampersTable = ({
               camper={selectedCamper}
               removeModalIsOpen={removeModalIsOpen}
               removeModalOnClose={removeModalOnClose}
+              handleRefetch={handleRefetch}
             />
           )}
         </>

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -30,6 +30,7 @@ import textStyles from "../../../../theme/textStyles";
 import CampersTableKebabMenu from "./CampersTableKebabMenu";
 import EditCamperModal from "../EditCamperModal";
 import ViewCamperModal from "../ViewCamperModal/index";
+import RemoveCamperModal from "../RemoveCamperModal/index";
 
 const ExportButton = (): JSX.Element => {
   return (
@@ -72,6 +73,12 @@ const CampersTable = ({
     isOpen: viewModalIsOpen,
     onOpen: viewModalOnOpen,
     onClose: viewModalOnClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: removeModalIsOpen,
+    onOpen: removeModalOnOpen,
+    onClose: removeModalOnClose,
   } = useDisclosure();
 
   const tableData = React.useMemo(() => {
@@ -242,7 +249,8 @@ const CampersTable = ({
                         console.log("Moving Camper");
                       }}
                       removeCamperFunc={() => {
-                        console.log("Removing Camper");
+                        setSelectedCamper(camper);
+                        removeModalOnOpen();
                       }}
                     />
                   </Td>
@@ -265,6 +273,14 @@ const CampersTable = ({
               camper={selectedCamper}
               viewCamperModalIsOpen={viewModalIsOpen}
               viewCamperOnClose={viewModalOnClose}
+            />
+          )}
+
+          {selectedCamper && (
+            <RemoveCamperModal
+              camper={selectedCamper}
+              removeModalIsOpen={removeModalIsOpen}
+              removeModalOnClose={removeModalOnClose}
             />
           )}
         </>

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -8,9 +8,13 @@ import WaitlistedCampersTable from "./WaitlistedCampersTable";
 
 type CampersTablesProps = {
   campSession: CampSession;
+  handleRefetch: () => void;
 };
 
-const CampersTables = ({ campSession }: CampersTablesProps): JSX.Element => {
+const CampersTables = ({
+  campSession,
+  handleRefetch,
+}: CampersTablesProps): JSX.Element => {
   return (
     <Box>
       <Tabs variant="line" colorScheme="green" outline="0" marginBottom="30px">
@@ -31,6 +35,7 @@ const CampersTables = ({ campSession }: CampersTablesProps): JSX.Element => {
             <CampersTable
               campers={campSession.campers}
               campSessionCapacity={campSession.capacity}
+              handleRefetch={handleRefetch}
             />
           </TabPanel>
           <TabPanel padding="0">

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
@@ -71,15 +71,13 @@ const ConfirmModal = ({
       <ModalFooter bg="camperModals.footer" borderRadius="8px">
         <Button
           variant="ghost"
-          onClick={() => {
-            deselectAndClose();
-          }}
+          onClick={deselectAndClose}
           mr={3}
         >
           Cancel
         </Button>
         <Button
-          colorScheme="red"
+          colorScheme='secondary.critical'
           onClick={() => {
             submitDeletion();
             deselectAndClose();

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
@@ -28,14 +28,12 @@ const ConfirmModal = ({
   return (
     <ModalContent maxWidth="400px" maxHeight="80%">
       <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
-        <Text textStyle="displaySmallerSemiBold">
-          Remove Camper(s) from Session
-        </Text>
+        <Text textStyle="buttonSemiBold">Remove Camper(s) from Session</Text>
       </ModalHeader>
 
       <ModalBody pl={8} pr={8} pb={0} pt={0}>
         <Box pt={4} pb={4}>
-          <Text textStyle="displaySmallRegular">
+          <Text textStyle="bodyRegular">
             Ensure that you have completed the following steps before removing
             the camper(s) from the camp session.
           </Text>
@@ -50,7 +48,7 @@ const ConfirmModal = ({
             </ListItem>
           </UnorderedList>
 
-          <Text textStyle="displaySmallRegular" pt={6}>
+          <Text textStyle="bodyRegular" pt={6}>
             The following campers are scheduled for deletion:
           </Text>
           <UnorderedList pt={2}>
@@ -63,21 +61,17 @@ const ConfirmModal = ({
             })}
           </UnorderedList>
 
-          <Text textStyle="displaySmallBold" pt={4}>
+          <Text textStyle="buttonSemiBold" pt={4}>
             Note: this action is irreversible.
           </Text>
         </Box>
       </ModalBody>
       <ModalFooter bg="camperModals.footer" borderRadius="8px">
-        <Button
-          variant="ghost"
-          onClick={deselectAndClose}
-          mr={3}
-        >
+        <Button variant="ghost" onClick={deselectAndClose} mr={3}>
           Cancel
         </Button>
         <Button
-          colorScheme='secondary.critical'
+          colorScheme="secondary.critical"
           onClick={() => {
             submitDeletion();
             deselectAndClose();

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/ConfirmModal.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+
+import {
+  Box,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  Text,
+  ListItem,
+  UnorderedList,
+} from "@chakra-ui/react";
+
+import { Camper } from "../../../../types/CamperTypes";
+
+type ConfirmModalProps = {
+  allCampersToBeDeleted: Camper[];
+  deselectAndClose: () => void;
+  submitDeletion: () => void;
+};
+
+const ConfirmModal = ({
+  allCampersToBeDeleted,
+  deselectAndClose,
+  submitDeletion,
+}: ConfirmModalProps): JSX.Element => {
+  return (
+    <ModalContent maxWidth="400px" maxHeight="80%">
+      <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
+        <Text textStyle="displaySmallerSemiBold">
+          Remove Camper(s) from Session
+        </Text>
+      </ModalHeader>
+
+      <ModalBody pl={8} pr={8} pb={0} pt={0}>
+        <Box pt={4} pb={4}>
+          <Text textStyle="displaySmallRegular">
+            Ensure that you have completed the following steps before removing
+            the camper(s) from the camp session.
+          </Text>
+          <UnorderedList pt={2}>
+            <ListItem>
+              Contacted the registrant to confirm that the camper(s) is/are to
+              be removed
+            </ListItem>
+            <ListItem>
+              Completed a full/partial refund or discussed an alternative
+              reimbursment
+            </ListItem>
+          </UnorderedList>
+
+          <Text textStyle="displaySmallRegular" pt={6}>
+            The following campers are scheduled for deletion:
+          </Text>
+          <UnorderedList pt={2}>
+            {allCampersToBeDeleted.map((currentCamper: Camper) => {
+              return (
+                <ListItem key={currentCamper.id}>
+                  {currentCamper.firstName} {currentCamper.lastName}
+                </ListItem>
+              );
+            })}
+          </UnorderedList>
+
+          <Text textStyle="displaySmallBold" pt={4}>
+            Note: this action is irreversible.
+          </Text>
+        </Box>
+      </ModalBody>
+      <ModalFooter bg="camperModals.footer" borderRadius="8px">
+        <Button
+          variant="ghost"
+          onClick={() => {
+            deselectAndClose();
+          }}
+          mr={3}
+        >
+          Cancel
+        </Button>
+        <Button
+          colorScheme="red"
+          onClick={() => {
+            submitDeletion();
+            deselectAndClose();
+          }}
+        >
+          Remove
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  );
+};
+
+export default ConfirmModal;

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
@@ -78,7 +78,7 @@ const SelectModal = ({
                   : setCampersToBeDeleted(new Set<Camper>())
               }
               mb={0}
-              colorScheme="green"
+              colorScheme="primary.green"
             >
               Select all
             </Checkbox>
@@ -93,7 +93,7 @@ const SelectModal = ({
                       ? removeCamperToBeDeleted(currentCamper)
                       : addCamperToBeDeleted(currentCamper)
                   }
-                  colorScheme="green"
+                  colorScheme="primary.green"
                 >
                   {currentCamper.firstName} {currentCamper.lastName}
                 </Checkbox>

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
@@ -102,7 +102,7 @@ const SelectModal = ({
         <Button variant="ghost" onClick={deselectAndClose} mr={3}>
           Cancel
         </Button>
-        <Button colorScheme="green" onClick={setStatusAsConfirm}>
+        <Button colorScheme="primary.green" onClick={setStatusAsConfirm}>
           Next
         </Button>
       </ModalFooter>

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
@@ -35,25 +35,31 @@ const SelectModal = ({
     setCampersToBeDeleted(new Set(campersToBeDeleted.add(newCamper)));
   };
 
-  const removeCamperToBeDeleted = (newCamper: Camper) => {
-    setCampersToBeDeleted(
-      new Set(
-        (Array.from(campersToBeDeleted) as Camper[]).filter(
-          (currentCamper: Camper) => currentCamper.id !== newCamper.id,
-        ),
-      ),
+  const removeCamperToBeDeleted = (oldCamper: Camper) => {
+    const newSet = new Set(campersToBeDeleted);
+    newSet.delete(oldCamper);
+    setCampersToBeDeleted(newSet);
+  };
+
+  const addAllCampers = () => {
+    const newSet = new Set<Camper>();
+
+    retrievedCampers.forEach((currentCamper: Camper) =>
+      newSet.add(currentCamper),
     );
+
+    setCampersToBeDeleted(newSet);
   };
 
   return (
     <ModalContent maxWidth="400px" maxHeight="80%">
       <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
-        <Text textStyle="displaySmallerSemiBold">Remove group members?</Text>
+        <Text textStyle="buttonSemiBold">Remove group members?</Text>
       </ModalHeader>
 
       <ModalBody pl={8} pr={8} pb={0} pt={0}>
         <Box pt={4} pb={4}>
-          <Text textStyle="displaySmallRegular">
+          <Text textStyle="bodyRegular">
             {camper.firstName} {camper.lastName} registered with the following
             group members. Please select all the group members you would also
             like to remove from this session:{" "}
@@ -68,9 +74,7 @@ const SelectModal = ({
               }
               onChange={() =>
                 campersToBeDeleted.size < retrievedCampers.length
-                  ? retrievedCampers.forEach((currentCamper: Camper) =>
-                      addCamperToBeDeleted(currentCamper),
-                    )
+                  ? addAllCampers()
                   : setCampersToBeDeleted(new Set<Camper>())
               }
               mb={0}

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/SelectModal.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+
+import {
+  Box,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  Text,
+  Checkbox,
+  Stack,
+} from "@chakra-ui/react";
+
+import { Camper } from "../../../../types/CamperTypes";
+
+type SelectModalProps = {
+  camper: Camper;
+  campersToBeDeleted: Set<Camper>;
+  setCampersToBeDeleted: React.Dispatch<React.SetStateAction<Set<Camper>>>;
+  retrievedCampers: Camper[];
+  deselectAndClose: () => void;
+  setStatusAsConfirm: () => void;
+};
+
+const SelectModal = ({
+  camper,
+  campersToBeDeleted,
+  setCampersToBeDeleted,
+  retrievedCampers,
+  deselectAndClose,
+  setStatusAsConfirm,
+}: SelectModalProps): JSX.Element => {
+  const addCamperToBeDeleted = (newCamper: Camper) => {
+    setCampersToBeDeleted(new Set(campersToBeDeleted.add(newCamper)));
+  };
+
+  const removeCamperToBeDeleted = (newCamper: Camper) => {
+    setCampersToBeDeleted(
+      new Set(
+        (Array.from(campersToBeDeleted) as Camper[]).filter(
+          (currentCamper: Camper) => currentCamper.id !== newCamper.id,
+        ),
+      ),
+    );
+  };
+
+  return (
+    <ModalContent maxWidth="400px" maxHeight="80%">
+      <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
+        <Text textStyle="displaySmallerSemiBold">Remove group members?</Text>
+      </ModalHeader>
+
+      <ModalBody pl={8} pr={8} pb={0} pt={0}>
+        <Box pt={4} pb={4}>
+          <Text textStyle="displaySmallRegular">
+            {camper.firstName} {camper.lastName} registered with the following
+            group members. Please select all the group members you would also
+            like to remove from this session:{" "}
+          </Text>
+
+          <Stack mt={4}>
+            <Checkbox
+              isChecked={campersToBeDeleted.size === retrievedCampers.length}
+              isIndeterminate={
+                campersToBeDeleted.size > 0 &&
+                campersToBeDeleted.size !== retrievedCampers.length
+              }
+              onChange={() =>
+                campersToBeDeleted.size < retrievedCampers.length
+                  ? retrievedCampers.forEach((currentCamper: Camper) =>
+                      addCamperToBeDeleted(currentCamper),
+                    )
+                  : setCampersToBeDeleted(new Set<Camper>())
+              }
+              mb={0}
+              colorScheme="green"
+            >
+              Select all
+            </Checkbox>
+
+            {retrievedCampers.map((currentCamper: Camper) => {
+              return (
+                <Checkbox
+                  key={currentCamper.id}
+                  isChecked={campersToBeDeleted.has(currentCamper)}
+                  onChange={() =>
+                    campersToBeDeleted.has(currentCamper)
+                      ? removeCamperToBeDeleted(currentCamper)
+                      : addCamperToBeDeleted(currentCamper)
+                  }
+                  colorScheme="green"
+                >
+                  {currentCamper.firstName} {currentCamper.lastName}
+                </Checkbox>
+              );
+            })}
+          </Stack>
+        </Box>
+      </ModalBody>
+      <ModalFooter bg="camperModals.footer" borderRadius="8px">
+        <Button variant="ghost" onClick={deselectAndClose} mr={3}>
+          Cancel
+        </Button>
+        <Button colorScheme="green" onClick={setStatusAsConfirm}>
+          Next
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  );
+};
+
+export default SelectModal;

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+
+import {
+  Box,
+  ModalOverlay,
+  ModalContent,
+  Modal,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  Text,
+  Checkbox,
+  Stack,
+  ListItem,
+  UnorderedList,
+} from "@chakra-ui/react";
+
+import { Camper } from "../../../../types/CamperTypes";
+
+type RemoveCamperModalProps = {
+  removeModalIsOpen: boolean;
+  removeModalOnClose: () => void;
+  camper: Camper;
+};
+
+const RemoveCamperModal = ({
+  removeModalIsOpen,
+  removeModalOnClose,
+  camper,
+}: RemoveCamperModalProps): JSX.Element => {
+  const [checkedItems, setCheckedItems] = React.useState([false, false]);
+
+  const allChecked = checkedItems.every(Boolean);
+  const isIndeterminate = checkedItems.some(Boolean) && !allChecked;
+
+  const [removeUsersPage, setRemoveUsersPage] = React.useState<boolean>(true);
+
+  return (
+    <Modal
+      isOpen={removeModalIsOpen}
+      onClose={removeModalOnClose}
+      isCentered
+      preserveScrollBarGap
+      scrollBehavior="inside"
+    >
+      <ModalOverlay />
+
+      {removeUsersPage ? (
+        <ModalContent maxWidth="400px" maxHeight="80%">
+          <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
+            <Text textStyle="displaySmallerSemiBold">
+              Remove group members?
+            </Text>
+          </ModalHeader>
+
+          <ModalBody pl={8} pr={8} pb={0} pt={0}>
+            <Box pt={4} pb={4}>
+              <Text textStyle="displaySmallRegular">
+                FirstName LastName registered with the following group members.
+                Please select all the group members you would also like to
+                remove from this session:{" "}
+              </Text>
+
+              <Stack mt={4}>
+                <Checkbox
+                  isChecked={allChecked}
+                  isIndeterminate={isIndeterminate}
+                  onChange={(e) =>
+                    setCheckedItems([e.target.checked, e.target.checked])
+                  }
+                  mb={0}
+                  colorScheme="green"
+                >
+                  Select all
+                </Checkbox>
+
+                <Checkbox
+                  isChecked={checkedItems[0]}
+                  onChange={(e) =>
+                    setCheckedItems([e.target.checked, checkedItems[1]])
+                  }
+                  colorScheme="green"
+                >
+                  Child Checkbox 1
+                </Checkbox>
+
+                <Checkbox
+                  isChecked={checkedItems[1]}
+                  onChange={(e) =>
+                    setCheckedItems([checkedItems[0], e.target.checked])
+                  }
+                  colorScheme="green"
+                >
+                  Child Checkbox 2
+                </Checkbox>
+              </Stack>
+            </Box>
+          </ModalBody>
+          <ModalFooter bg="camperModals.footer" borderRadius="8px">
+            <Button variant="ghost" onClick={removeModalOnClose} mr={3}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="green"
+              onClick={() => setRemoveUsersPage(false)}
+            >
+              Next
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      ) : (
+        <ModalContent maxWidth="400px" maxHeight="80%">
+          <ModalHeader ml={8} mr={8} pt={8} pb={4} pl={0} pr={0}>
+            <Text textStyle="displaySmallerSemiBold">
+              Remove Camper(s) from Session
+            </Text>
+          </ModalHeader>
+
+          <ModalBody pl={8} pr={8} pb={0} pt={0}>
+            <Box pt={4} pb={4}>
+              <Text textStyle="displaySmallRegular">
+                Ensure that you have completed the following steps before
+                removing the camper(s) from the camp session.
+                <UnorderedList>
+                  <ListItem>
+                    Contacted the registrant to confirm that the camper(s)
+                    is/are to be removed
+                  </ListItem>
+                  <ListItem>
+                    Completed a full/partial refund or discussed an alternative
+                    reimbursment
+                  </ListItem>
+                </UnorderedList>
+              </Text>
+
+              <Text textStyle="displaySmallBold" pt={4}>
+                Note: this action is irreversible.
+              </Text>
+            </Box>
+          </ModalBody>
+          <ModalFooter bg="camperModals.footer" borderRadius="8px">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                removeModalOnClose();
+                setRemoveUsersPage(true);
+              }}
+              mr={3}
+            >
+              Cancel
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={() => {
+                removeModalOnClose();
+                setRemoveUsersPage(true);
+              }}
+            >
+              Remove
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      )}
+    </Modal>
+  );
+};
+
+export default RemoveCamperModal;

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
@@ -72,7 +72,7 @@ const RemoveCamperModal = ({
       setRetrievedCampers([]);
       setCampersToBeDeleted(new Set<Camper>());
     };
-  }, [camper]);
+  }, [camper, toast]);
 
   const deselectAndClose = () => {
     setCampersToBeDeleted(new Set<Camper>());
@@ -120,6 +120,15 @@ const RemoveCamperModal = ({
     handleRefetch();
   };
 
+  const showSelectModal = () =>
+    modalStatus === ModalStatus.SELECT &&
+    retrievedCampers.length > 0 &&
+    !loading;
+
+  const showConfirmModal = () =>
+    (modalStatus === ModalStatus.CONFIRM || retrievedCampers.length === 0) &&
+    !loading;
+
   return (
     <Modal
       isOpen={removeModalIsOpen}
@@ -130,27 +139,24 @@ const RemoveCamperModal = ({
     >
       <ModalOverlay />
 
-      {modalStatus === ModalStatus.SELECT &&
-        retrievedCampers.length > 0 &&
-        !loading && (
-          <SelectModal
-            camper={camper}
-            campersToBeDeleted={campersToBeDeleted}
-            setCampersToBeDeleted={setCampersToBeDeleted}
-            retrievedCampers={retrievedCampers}
-            deselectAndClose={deselectAndClose}
-            setStatusAsConfirm={() => setModalStatus(ModalStatus.CONFIRM)}
-          />
-        )}
+      {showSelectModal() && (
+        <SelectModal
+          camper={camper}
+          campersToBeDeleted={campersToBeDeleted}
+          setCampersToBeDeleted={setCampersToBeDeleted}
+          retrievedCampers={retrievedCampers}
+          deselectAndClose={deselectAndClose}
+          setStatusAsConfirm={() => setModalStatus(ModalStatus.CONFIRM)}
+        />
+      )}
 
-      {(modalStatus === ModalStatus.CONFIRM || retrievedCampers.length === 0) &&
-        !loading && (
-          <ConfirmModal
-            allCampersToBeDeleted={allCampersToBeDeleted}
-            deselectAndClose={deselectAndClose}
-            submitDeletion={submitDeletion}
-          />
-        )}
+      {showConfirmModal() && (
+        <ConfirmModal
+          allCampersToBeDeleted={allCampersToBeDeleted}
+          deselectAndClose={deselectAndClose}
+          submitDeletion={submitDeletion}
+        />
+      )}
     </Modal>
   );
 };

--- a/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/RemoveCamperModal/index.tsx
@@ -61,7 +61,7 @@ const RemoveCamperModal = ({
         toast({
           description: `Unable to retrieve camper information.`,
           status: "error",
-          duration: 5000,
+          duration: 3000,
           variant: "subtle",
         });
       }
@@ -106,14 +106,14 @@ const RemoveCamperModal = ({
       toast({
         description: deletionMessage(),
         status: "success",
-        duration: 5000,
+        duration: 3000,
         variant: "subtle",
       });
     } else {
       toast({
         description: `Unable to remove the selected campers.`,
         status: "error",
-        duration: 5000,
+        duration: 3000,
         variant: "subtle",
       });
     }

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -44,6 +44,11 @@ const CampOverviewPage = (): JSX.Element => {
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  const [refetch, setRefetch] = useState<boolean>(true);
+  const handleRefetch = () => {
+    setRefetch(!refetch);
+  };
+
   useEffect(() => {
     const getCamp = async () => {
       const campResponse = await CampsAPIClient.getCampById(campId);
@@ -52,7 +57,7 @@ const CampOverviewPage = (): JSX.Element => {
       }
     };
     getCamp();
-  }, [campId]);
+  }, [campId, refetch]);
 
   const onNextSession = () => {
     if (numSessions >= 2)
@@ -97,6 +102,7 @@ const CampOverviewPage = (): JSX.Element => {
             />
             <CampersTables
               campSession={camp.campSessions[currentCampSession]}
+              handleRefetch={handleRefetch}
             />
             <ManageSessionsModal
               campStartTime={camp.startTime}

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -42,11 +42,6 @@ const CampOverviewPage = (): JSX.Element => {
   });
   const numSessions = camp.campSessions?.length;
 
-  const [refetch, setRefetch] = useState<boolean>(true);
-  const handleRefetch = () => {
-    setRefetch(!refetch);
-  };
-
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [refetch, setRefetch] = useState<boolean>(true);

--- a/frontend/src/theme/colors.ts
+++ b/frontend/src/theme/colors.ts
@@ -2,11 +2,13 @@ const colors = {
   primary: {
     green: {
       100: "#468740",
+      500: "#468740",
     },
   },
   secondary: {
     critical: {
       100: "#F8533D",
+      500: "#F8533D",
     },
     warning: {
       100: "#F39E3B",

--- a/frontend/src/theme/textStyles.ts
+++ b/frontend/src/theme/textStyles.ts
@@ -36,6 +36,11 @@ const textStyles = {
     fontSize: "18px",
     lineHeight: "150%",
   },
+  displaySmallerSemiBold: {
+    fontWeight: FontWeights.SEMIBOLD,
+    fontSize: "18px",
+    lineHeight: "150%",
+  },
   displaySmallRegular: {
     fontWeight: FontWeights.REGULAR,
     fontSize: "24px",

--- a/frontend/src/theme/textStyles.ts
+++ b/frontend/src/theme/textStyles.ts
@@ -36,11 +36,6 @@ const textStyles = {
     fontSize: "18px",
     lineHeight: "150%",
   },
-  displaySmallerSemiBold: {
-    fontWeight: FontWeights.SEMIBOLD,
-    fontSize: "18px",
-    lineHeight: "150%",
-  },
   displaySmallRegular: {
     fontWeight: FontWeights.REGULAR,
     fontSize: "24px",

--- a/frontend/src/types/CamperTypes.ts
+++ b/frontend/src/types/CamperTypes.ts
@@ -1,6 +1,7 @@
 export type Camper = {
   id: string;
   // campSession: CampSession;
+  campSession: string;
   firstName: string;
   lastName: string;
   age: number;

--- a/frontend/src/types/CamperTypes.ts
+++ b/frontend/src/types/CamperTypes.ts
@@ -1,6 +1,5 @@
 export type Camper = {
   id: string;
-  // campSession: CampSession;
   campSession: string;
   firstName: string;
   lastName: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Remove Camper(s) from session](https://www.notion.so/uwblueprintexecs/Camp-Overview-Remove-Camper-s-from-session-9c2c0522fc6c41f9a3e34203f2d0bd65)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created new functions to delete campers by id and get campers that have the same specified charge id and session id, in `CamperAPIClient.ts`
* Added implementation for `getCampersByChargeIdAndSessionId` in the `CamperService.ts` files
* Created a new route for this endpoint to use
* Made the modals to interact with everything
![image](https://user-images.githubusercontent.com/30396273/195475310-59110798-9a7e-4496-b4f6-1f3810d220ce.png)
![image](https://user-images.githubusercontent.com/30396273/195475323-89aeed05-dcbd-42a5-a371-251f54d0585d.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to the Guelph camp for instance, http://localhost:3000/admin/camp/63139c7bc3d7b55b44a01531
2. Remove different campers, ensure it works


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensure that removing campers with different session ids and charge ids are seperated (i.e. in the checkbox that pops up when removing, the checkbox should only contain campers with the same charge and session ids; if a camper doesn't share their session or charge id with anyone else, the select modal should not pop up)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
