### PR TITLE
added the addQuestionToFormTemplate in the admin service

### DIFF
--- a/backend/typescript/middlewares/validators/adminValidators.ts
+++ b/backend/typescript/middlewares/validators/adminValidators.ts
@@ -49,3 +49,14 @@ export const formTemplateUpdateValidator = async (
   }
   return next();
 };
+
+export const formTemplateAddQuestionValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!req.body.formQuestion || !validateFormQuestion(req.body.formQuestion)) {
+    return res.status(400).send("Invalid format provided for form question");
+  }
+  return next();
+};

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -6,10 +6,13 @@ import { getErrorMessage } from "../utilities/errorUtils";
 import {
   waiverUpdateValidator,
   formTemplateUpdateValidator,
+  formTemplateAddQuestionValidator,
 } from "../middlewares/validators/adminValidators";
+import { isAuthorizedByRole } from "../middlewares/auth";
 
 const adminRouter: Router = Router();
 const adminService: IAdminService = new AdminService();
+
 adminRouter.post("/waiver", waiverUpdateValidator, async (req, res) => {
   try {
     const waiver = await adminService.updateWaiver({
@@ -53,5 +56,26 @@ adminRouter.get("/formTemplate", async (req, res) => {
     res.status(500).json({ error: getErrorMessage(error) });
   }
 });
+
+adminRouter.patch(
+  "/formTemplate/formQuestion",
+  formTemplateAddQuestionValidator,
+  // isAuthorizedByRole(new Set(["Admin"])),
+  async (req, res) => {
+    try {
+      const newQuestion = await adminService.addQuestionToTemplate({
+        question: req.body.formQuestion.question,
+        required: req.body.formQuestion.required,
+        category: req.body.formQuestion.category,
+        options: req.body.formQuestion.options,
+        description: req.body.formQuestion.description,
+        type: req.body.formQuestion.type,
+      });
+      res.status(200).json(newQuestion);
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  },
+);
 
 export default adminRouter;

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -60,7 +60,7 @@ adminRouter.get("/formTemplate", async (req, res) => {
 adminRouter.patch(
   "/formTemplate/formQuestion",
   formTemplateAddQuestionValidator,
-  // isAuthorizedByRole(new Set(["Admin"])),
+  isAuthorizedByRole(new Set(["Admin"])),
   async (req, res) => {
     try {
       const newQuestion = await adminService.addQuestionToTemplate({

--- a/backend/typescript/services/implementations/adminService.ts
+++ b/backend/typescript/services/implementations/adminService.ts
@@ -123,11 +123,11 @@ class AdminService implements IAdminService {
 
     try {
       // Get the current formTemplate and its list of questions
-      const formTemplate = await MgFormTemplate.findOne();
-      
-      if (!formTemplate){
+      const formTemplate = await MgFormTemplate.findOne({}, {}, { session });
+
+      if (!formTemplate) {
         throw new Error("Failed to retrieve the form template");
-      }  
+      }
 
       const newFormQuestion = await MgFormQuestion.create({
         type: formQuestion.type,
@@ -139,7 +139,7 @@ class AdminService implements IAdminService {
       });
 
       formTemplate.formQuestions.push(newFormQuestion._id);
-      await formTemplate.save();
+      await formTemplate.save({ session });
       await session.commitTransaction();
 
       return {

--- a/backend/typescript/services/implementations/adminService.ts
+++ b/backend/typescript/services/implementations/adminService.ts
@@ -124,8 +124,10 @@ class AdminService implements IAdminService {
     try {
       // Get the current formTemplate and its list of questions
       const formTemplate = await MgFormTemplate.findOne();
-      if (!formTemplate)
+      
+      if (!formTemplate){
         throw new Error("Failed to retrieve the form template");
+      }  
 
       const newFormQuestion = await MgFormQuestion.create({
         type: formQuestion.type,
@@ -156,8 +158,9 @@ class AdminService implements IAdminService {
         )}`,
       );
       await session.abortTransaction();
-      await session.endSession();
       throw error;
+    } finally {
+      await session.endSession();
     }
   }
 }

--- a/backend/typescript/services/implementations/adminService.ts
+++ b/backend/typescript/services/implementations/adminService.ts
@@ -1,6 +1,12 @@
+import mongoose from "mongoose";
 import IAdminService from "../interfaces/adminService";
 import MgWaiver, { Waiver } from "../../models/waiver.model";
-import { FormQuestionDTO, FormTemplateDTO, WaiverDTO } from "../../types";
+import {
+  FormQuestionDTO,
+  FormTemplateDTO,
+  WaiverDTO,
+  CreateFormQuestionDTO,
+} from "../../types";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import MgFormTemplate from "../../models/formTemplate.model";
@@ -107,6 +113,52 @@ class AdminService implements IAdminService {
       throw error;
     }
     return form;
+  }
+
+  async addQuestionToTemplate(
+    formQuestion: CreateFormQuestionDTO,
+  ): Promise<FormQuestionDTO> {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+      // Get the current formTemplate and its list of questions
+      const formTemplate = await MgFormTemplate.findOne();
+      if (!formTemplate)
+        throw new Error("Failed to retrieve the form template");
+
+      const newFormQuestion = await MgFormQuestion.create({
+        type: formQuestion.type,
+        question: formQuestion.question,
+        required: formQuestion.required,
+        description: formQuestion.description,
+        options: formQuestion.options,
+        category: formQuestion.category,
+      });
+
+      formTemplate.formQuestions.push(newFormQuestion._id);
+      await formTemplate.save();
+      await session.commitTransaction();
+
+      return {
+        type: newFormQuestion.type,
+        question: newFormQuestion.question,
+        required: newFormQuestion.required,
+        description: newFormQuestion.description,
+        options: newFormQuestion.options,
+        id: newFormQuestion.id,
+        category: newFormQuestion.category,
+      };
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to add form question to form template. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      await session.abortTransaction();
+      await session.endSession();
+      throw error;
+    }
   }
 }
 

--- a/backend/typescript/services/interfaces/adminService.ts
+++ b/backend/typescript/services/interfaces/adminService.ts
@@ -1,4 +1,9 @@
-import { FormTemplateDTO, WaiverDTO } from "../../types";
+import {
+  FormQuestionDTO,
+  FormTemplateDTO,
+  WaiverDTO,
+  CreateFormQuestionDTO,
+} from "../../types";
 
 interface IAdminService {
   /**
@@ -8,24 +13,36 @@ interface IAdminService {
    * @throws Error if waiver creation or update fails.
    */
   updateWaiver(waiver: WaiverDTO): Promise<WaiverDTO>;
+
   /**
    * Get the waiver.
    * @returns A WaiverDTO that contains the waiver.
    * @throws Error if waiver retrieval fails.
    */
   getWaiver(): Promise<WaiverDTO>;
+
   /**
    * Creates a new form template or updates it if it already exists.
    * @returns A FormTemplateDTO that contains the waiver.
    * @throws Error if form template retrieval fails.
    */
   updateFormTemplate(form: FormTemplateDTO): Promise<FormTemplateDTO>;
+
   /**
    * Get the form.
    * @returns A FormTemplateDTO that contains the waiver.
    * @throws Error if form template retrieval fails.
    */
   getFormTemplate(): Promise<FormTemplateDTO>;
+
+  /**
+   * Add a question to the form template
+   * @returns a FormQuestionDTO for the new form
+   * @throws Error if adding the form question fails
+   */
+  addQuestionToTemplate(
+    formQuestion: CreateFormQuestionDTO,
+  ): Promise<FormQuestionDTO>;
 }
 
 export default IAdminService;

--- a/backend/typescript/services/interfaces/adminService.ts
+++ b/backend/typescript/services/interfaces/adminService.ts
@@ -38,6 +38,7 @@ interface IAdminService {
   /**
    * Add a question to the form template
    * @returns a FormQuestionDTO for the new form
+   * @param formQuestion is an object with the fields of the new question to be added to the template
    * @throws Error if adding the form question fails
    */
   addQuestionToTemplate(

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -33,6 +33,8 @@ export type FormQuestionDTO = {
   options?: string[];
 };
 
+export type CreateFormQuestionDTO = Omit<FormQuestionDTO, "id">;
+
 export type CampCoordinatorDTO = UserDTO & { campSessions: string[] };
 
 export type CamperDTO = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Form Management: Add question to form template](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=872084408d3543a3ad120dcc9808a9a1&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* just your standard endpoint changes tbh
* decided to make the body of the form `formQuestion: {...}` instead of just the fields. This was to leverage the existing `validateFormQuestion()` function more directly. 
* Decided to implement this function in the adminService as I think it does belong there. Some of the existing work for formquestions seems to be in the `campService` but I think it's better suited here. (For camp creation, I think we should add new functions like `addQuestionsToCamp` like the one I added in this PR)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Make a PATCH request to `http://localhost:5000/admin/formTemplate/formQuestion/` (you might need to disable the `isAuthorizedByRole()` middleware or figure out how to add auth to POSTMAN requests)
2. Use the following body: 
```
{
    "formQuestion" : {
        "type" : "Text",
        "category": "PersonalInfo",
        "question": "What previous photography experience do you have?",
        "required" : false
    }
}
```
3. Log on to the mongodb console and see that the question id was APPENDED to the list of questions in the template and that the question was created in the `formQuestion` collection
4. The response should have the newly created formQuestion


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Use of transactions ok? 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
