### PR TITLE
Frontend - Waiver Section Edit/Delete

### DIFF
--- a/frontend/src/components/pages/GlobalForms/WaiverTab/DeleteWaiverModal.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/DeleteWaiverModal.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalFooter,
+  ModalBody,
+  Button,
+} from "@chakra-ui/react";
+
+interface DeleteWaiverModalProps {
+  deleteModalIsOpen: boolean;
+  clauseIdx: number;
+  onDeleteWaiverSection: (clauseIdx: number) => void;
+  onDeleteModalClose: () => void;
+}
+const WaiverSectionCard = ({
+  deleteModalIsOpen,
+  clauseIdx,
+  onDeleteModalClose,
+  onDeleteWaiverSection,
+}: DeleteWaiverModalProps): JSX.Element => {
+  function onDeleteConfirm() {
+    onDeleteWaiverSection(clauseIdx);
+    onDeleteModalClose();
+  }
+
+  return (
+    <Modal
+      isOpen={deleteModalIsOpen}
+      onClose={onDeleteModalClose}
+      isCentered
+      preserveScrollBarGap
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalBody>
+          <Text mt="16px" textStyle="heading">
+            Delete waiver section?
+          </Text>
+
+          <Text mb="28px" mt="12px" textStyle="bodyRegular">
+            Are you sure you want to delete this waiver section?
+          </Text>
+
+          <Text textStyle="bodyBold">Note: this action is irreversible.</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button mr={3} onClick={onDeleteModalClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="red" onClick={onDeleteConfirm}>
+            Remove
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default WaiverSectionCard;

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/EditWaiverModal.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/EditWaiverModal.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import {
+  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Button,
+  Textarea,
+  Checkbox,
+} from "@chakra-ui/react";
+import { WaiverClause } from "../../../../types/AdminTypes";
+
+interface EditWaiverModalProps {
+  editModalIsOpen: boolean;
+  clauseIdx: number;
+  clauseData: WaiverClause;
+  onEditWaiverSection: (clause: WaiverClause, clauseIdx: number) => void;
+  onEditModalClose: () => void;
+}
+const WaiverSectionCard = ({
+  editModalIsOpen,
+  clauseIdx,
+  clauseData,
+  onEditWaiverSection,
+  onEditModalClose,
+}: EditWaiverModalProps): JSX.Element => {
+  const [clauseText, setClauseText] = React.useState(clauseData.text);
+  const [isRequired, setIsRequired] = React.useState(clauseData.required);
+
+  function onEditConfirm() {
+    const newClause = { text: clauseText, required: isRequired };
+    onEditWaiverSection(newClause, clauseIdx);
+    onEditModalClose();
+  }
+
+  return (
+    <Modal
+      isOpen={editModalIsOpen}
+      onClose={onEditModalClose}
+      isCentered
+      preserveScrollBarGap
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle="heading">Edit waiver section</Text>
+        </ModalHeader>
+        <ModalBody>
+          <Text textStyle="bodyRegular">Edit waiver</Text>
+          <Textarea
+            my="8px"
+            value={clauseText}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+              setClauseText(e.target.value);
+            }}
+            textStyle="bodyRegular"
+            h="300px"
+          />
+          <Checkbox
+            size="md"
+            isChecked={isRequired}
+            colorScheme="green"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setIsRequired(e.target.checked)
+            }
+          >
+            Mark as a required section
+          </Checkbox>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button mr={3} onClick={onEditModalClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="green" onClick={onEditConfirm}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default WaiverSectionCard;

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
@@ -1,21 +1,62 @@
 import React from "react";
-import { Text, Box, Flex, HStack, Spacer } from "@chakra-ui/react";
+import { Text, Box, Flex, HStack, Spacer, Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+ Button, Textarea, Checkbox } from "@chakra-ui/react";
 import { WaiverClause } from "../../../../types/AdminTypes";
 
 interface WaiverSectionCardProps {
   clauseIdx: number;
   clauseData: WaiverClause;
+  onEditWaiverSection: (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => void;
+  onDeleteWaiverSection: (idx: number) => void;
 }
 const WaiverSectionCard = ({
   clauseIdx,
   clauseData,
+  onEditWaiverSection,
+  onDeleteWaiverSection,
 }: WaiverSectionCardProps): JSX.Element => {
   function getSectionTitle(number: number) {
     const code = "A".charCodeAt(0);
     return `Section ${String.fromCharCode(code + number)}`;
   }
 
+  const [clauseText, setClauseText] = React.useState(clauseData.text)
+  const [isRequired, setIsRequired] = React.useState(clauseData.required)
+  const [isDeleteOpen, setDeleteOpen] = React.useState(false)
+  const [isEditOpen, setEditOpen] = React.useState(false)
+
+  function onDeleteOpen() {
+    setDeleteOpen(true)
+  }
+  function onDeleteClose() {
+    setDeleteOpen(false)
+  }
+
+  function onDeleteConfirm() {
+    onDeleteWaiverSection(clauseIdx)
+    setDeleteOpen(false)
+  }
+
+  function onEditOpen() {
+    setEditOpen(true)
+  }
+  function onEditClose() {
+    setEditOpen(false)
+  }
+
+  function onEditConfirm() {
+    onEditWaiverSection(clauseText, isRequired, clauseIdx)
+    setEditOpen(false)
+  }
+
+
   return (
+    <>
     <Box px="32px" pt="20px" pb="22px" bg="background.grey.100" my="12px">
       <Flex pb="14px">
         <HStack spacing="20px">
@@ -35,16 +76,67 @@ const WaiverSectionCard = ({
         </HStack>
         <Spacer />
         <HStack spacing="20px">
-          <Text textStyle="buttonSemiBold" color="text.success.100">
+          <Text textStyle="buttonSemiBold" _hover={{cursor: "pointer" }} onClick={onEditOpen} color="text.success.100">
             Edit
           </Text>
-          <Text textStyle="buttonSemiBold" color="text.critical.100">
+          <Text textStyle="buttonSemiBold" _hover={{cursor: "pointer" }} onClick={onDeleteOpen} color="text.critical.100">
             Delete
           </Text>
         </HStack>
       </Flex>
       <Text>{clauseData.text}</Text>
     </Box>
+    <>
+      <Modal isOpen={isEditOpen} onClose={onEditClose}>
+      <ModalOverlay />
+        <ModalContent>
+          <ModalHeader><Text textStyle="heading">
+          Edit waiver section
+          </Text></ModalHeader>
+          <ModalBody>
+            <Text textStyle="bodyRegular">Edit waiver</Text>
+            <Textarea
+              value={clauseText}
+              onChange={(e : React.ChangeEvent<HTMLTextAreaElement>) => { setClauseText(e.target.value)}}
+              textStyle="bodyRegular"
+              h="300px"
+            />
+            <Checkbox size='md' isChecked={isRequired} colorScheme='green' onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsRequired(e.target.checked)}>
+            Mark as a required section
+            </Checkbox>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button mr={3} onClick={onEditClose}>
+              Cancel
+            </Button>
+            <Button colorScheme='green' onClick={onEditConfirm}> Save </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+    <Modal isOpen={isDeleteOpen} onClose={onDeleteClose}>
+    <ModalOverlay />
+        <ModalContent>
+          <ModalHeader><Text textStyle="heading">
+          Delete waiver section? 
+          </Text></ModalHeader>
+          <ModalBody>
+          <Text textStyle="bodyRegular">Are you sure you want to delete this waiver section?</Text>
+
+         <Text textStyle="bodyBold">Note: this action is irreversible.</Text>
+          </ModalBody>
+
+          <ModalFooter>
+          <Button mr={3} onClick={onDeleteClose}>
+              Cancel
+            </Button>
+            <Button colorScheme='red' onClick={onDeleteConfirm}> Remove </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+    </>
   );
 };
 

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
@@ -5,26 +5,16 @@ import {
   Flex,
   HStack,
   Spacer,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  Button,
-  Textarea,
-  Checkbox,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { WaiverClause } from "../../../../types/AdminTypes";
+import EditWaiverModal from "./EditWaiverModal";
+import DeleteWaiverModal from "./DeleteWaiverModal";
 
 interface WaiverSectionCardProps {
   clauseIdx: number;
   clauseData: WaiverClause;
-  onEditWaiverSection: (
-    clauseText: string,
-    clauseIsRequired: boolean,
-    clauseIdx: number,
-  ) => void;
+  onEditWaiverSection: (clause: WaiverClause, clauseIdx: number) => void;
   onDeleteWaiverSection: (idx: number) => void;
 }
 const WaiverSectionCard = ({
@@ -38,34 +28,17 @@ const WaiverSectionCard = ({
     return `Section ${String.fromCharCode(code + number)}`;
   }
 
-  const [clauseText, setClauseText] = React.useState(clauseData.text);
-  const [isRequired, setIsRequired] = React.useState(clauseData.required);
-  const [isDeleteOpen, setDeleteOpen] = React.useState(false);
-  const [isEditOpen, setEditOpen] = React.useState(false);
+  const {
+    isOpen: editModalIsOpen,
+    onOpen: editModalOnOpen,
+    onClose: editModalOnClose,
+  } = useDisclosure();
 
-  function onDeleteOpen() {
-    setDeleteOpen(true);
-  }
-  function onDeleteClose() {
-    setDeleteOpen(false);
-  }
-
-  function onDeleteConfirm() {
-    onDeleteWaiverSection(clauseIdx);
-    setDeleteOpen(false);
-  }
-
-  function onEditOpen() {
-    setEditOpen(true);
-  }
-  function onEditClose() {
-    setEditOpen(false);
-  }
-
-  function onEditConfirm() {
-    onEditWaiverSection(clauseText, isRequired, clauseIdx);
-    setEditOpen(false);
-  }
+  const {
+    isOpen: deleteModalIsOpen,
+    onOpen: deleteModalOnOpen,
+    onClose: deleteModalOnClose,
+  } = useDisclosure();
 
   return (
     <>
@@ -91,7 +64,7 @@ const WaiverSectionCard = ({
             <Text
               textStyle="buttonSemiBold"
               _hover={{ cursor: "pointer" }}
-              onClick={onEditOpen}
+              onClick={editModalOnOpen}
               color="text.success.100"
             >
               Edit
@@ -99,7 +72,7 @@ const WaiverSectionCard = ({
             <Text
               textStyle="buttonSemiBold"
               _hover={{ cursor: "pointer" }}
-              onClick={onDeleteOpen}
+              onClick={deleteModalOnOpen}
               color="text.critical.100"
             >
               Delete
@@ -108,72 +81,19 @@ const WaiverSectionCard = ({
         </Flex>
         <Text>{clauseData.text}</Text>
       </Box>
-      <>
-        <Modal isOpen={isEditOpen} onClose={onEditClose} isCentered>
-          <ModalOverlay />
-          <ModalContent>
-            <ModalHeader>
-              <Text textStyle="heading">Edit waiver section</Text>
-            </ModalHeader>
-            <ModalBody>
-              <Text textStyle="bodyRegular">Edit waiver</Text>
-              <Textarea
-                my="8px"
-                value={clauseText}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-                  setClauseText(e.target.value);
-                }}
-                textStyle="bodyRegular"
-                h="300px"
-              />
-              <Checkbox
-                size="md"
-                isChecked={isRequired}
-                colorScheme="green"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setIsRequired(e.target.checked)
-                }
-              >
-                Mark as a required section
-              </Checkbox>
-            </ModalBody>
-
-            <ModalFooter>
-              <Button mr={3} onClick={onEditClose}>
-                Cancel
-              </Button>
-              <Button colorScheme="green" onClick={onEditConfirm}>
-                Save
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-      </>
-      <Modal isOpen={isDeleteOpen} onClose={onDeleteClose} isCentered>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalBody>
-            <Text mt="16px" textStyle="heading">
-              Delete waiver section?
-            </Text>
-
-            <Text mb="28px" mt="12px" textStyle="bodyRegular">
-              Are you sure you want to delete this waiver section?
-            </Text>
-
-            <Text textStyle="bodyBold">Note: this action is irreversible.</Text>
-          </ModalBody>
-
-          <ModalFooter>
-            <Button mr={3} onClick={onDeleteClose}>
-              Cancel
-            </Button>
-            <Button colorScheme="red" onClick={onDeleteConfirm}>
-              Remove
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      <EditWaiverModal
+        clauseData={clauseData}
+        clauseIdx={clauseIdx}
+        onEditModalClose={editModalOnClose}
+        onEditWaiverSection={onEditWaiverSection}
+        editModalIsOpen={editModalIsOpen}
+      />
+      <DeleteWaiverModal
+        deleteModalIsOpen={deleteModalIsOpen}
+        clauseIdx={clauseIdx}
+        onDeleteModalClose={deleteModalOnClose}
+        onDeleteWaiverSection={onDeleteWaiverSection}
+      />
     </>
   );
 };

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/WaiverSectionCard.tsx
@@ -1,17 +1,30 @@
 import React from "react";
-import { Text, Box, Flex, HStack, Spacer, Modal,
+import {
+  Text,
+  Box,
+  Flex,
+  HStack,
+  Spacer,
+  Modal,
   ModalOverlay,
   ModalContent,
   ModalHeader,
   ModalFooter,
   ModalBody,
- Button, Textarea, Checkbox } from "@chakra-ui/react";
+  Button,
+  Textarea,
+  Checkbox,
+} from "@chakra-ui/react";
 import { WaiverClause } from "../../../../types/AdminTypes";
 
 interface WaiverSectionCardProps {
   clauseIdx: number;
   clauseData: WaiverClause;
-  onEditWaiverSection: (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => void;
+  onEditWaiverSection: (
+    clauseText: string,
+    clauseIsRequired: boolean,
+    clauseIdx: number,
+  ) => void;
   onDeleteWaiverSection: (idx: number) => void;
 }
 const WaiverSectionCard = ({
@@ -25,117 +38,142 @@ const WaiverSectionCard = ({
     return `Section ${String.fromCharCode(code + number)}`;
   }
 
-  const [clauseText, setClauseText] = React.useState(clauseData.text)
-  const [isRequired, setIsRequired] = React.useState(clauseData.required)
-  const [isDeleteOpen, setDeleteOpen] = React.useState(false)
-  const [isEditOpen, setEditOpen] = React.useState(false)
+  const [clauseText, setClauseText] = React.useState(clauseData.text);
+  const [isRequired, setIsRequired] = React.useState(clauseData.required);
+  const [isDeleteOpen, setDeleteOpen] = React.useState(false);
+  const [isEditOpen, setEditOpen] = React.useState(false);
 
   function onDeleteOpen() {
-    setDeleteOpen(true)
+    setDeleteOpen(true);
   }
   function onDeleteClose() {
-    setDeleteOpen(false)
+    setDeleteOpen(false);
   }
 
   function onDeleteConfirm() {
-    onDeleteWaiverSection(clauseIdx)
-    setDeleteOpen(false)
+    onDeleteWaiverSection(clauseIdx);
+    setDeleteOpen(false);
   }
 
   function onEditOpen() {
-    setEditOpen(true)
+    setEditOpen(true);
   }
   function onEditClose() {
-    setEditOpen(false)
+    setEditOpen(false);
   }
 
   function onEditConfirm() {
-    onEditWaiverSection(clauseText, isRequired, clauseIdx)
-    setEditOpen(false)
+    onEditWaiverSection(clauseText, isRequired, clauseIdx);
+    setEditOpen(false);
   }
-
 
   return (
     <>
-    <Box px="32px" pt="20px" pb="22px" bg="background.grey.100" my="12px">
-      <Flex pb="14px">
-        <HStack spacing="20px">
-          <Text textStyle="displaySmallSemiBold">
-            {getSectionTitle(clauseIdx)}
-          </Text>
-          {clauseData.required && (
+      <Box px="32px" pt="20px" pb="22px" bg="background.grey.100" my="12px">
+        <Flex pb="14px">
+          <HStack spacing="20px">
+            <Text textStyle="displaySmallSemiBold">
+              {getSectionTitle(clauseIdx)}
+            </Text>
+            {clauseData.required && (
+              <Text
+                borderRadius="50px"
+                px={4}
+                bg="background.required.100"
+                color="text.critical.100"
+              >
+                required
+              </Text>
+            )}
+          </HStack>
+          <Spacer />
+          <HStack spacing="20px">
             <Text
-              borderRadius="50px"
-              px={4}
-              bg="background.required.100"
+              textStyle="buttonSemiBold"
+              _hover={{ cursor: "pointer" }}
+              onClick={onEditOpen}
+              color="text.success.100"
+            >
+              Edit
+            </Text>
+            <Text
+              textStyle="buttonSemiBold"
+              _hover={{ cursor: "pointer" }}
+              onClick={onDeleteOpen}
               color="text.critical.100"
             >
-              required
+              Delete
             </Text>
-          )}
-        </HStack>
-        <Spacer />
-        <HStack spacing="20px">
-          <Text textStyle="buttonSemiBold" _hover={{cursor: "pointer" }} onClick={onEditOpen} color="text.success.100">
-            Edit
-          </Text>
-          <Text textStyle="buttonSemiBold" _hover={{cursor: "pointer" }} onClick={onDeleteOpen} color="text.critical.100">
-            Delete
-          </Text>
-        </HStack>
-      </Flex>
-      <Text>{clauseData.text}</Text>
-    </Box>
-    <>
-      <Modal isOpen={isEditOpen} onClose={onEditClose}>
-      <ModalOverlay />
+          </HStack>
+        </Flex>
+        <Text>{clauseData.text}</Text>
+      </Box>
+      <>
+        <Modal isOpen={isEditOpen} onClose={onEditClose} isCentered>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader>
+              <Text textStyle="heading">Edit waiver section</Text>
+            </ModalHeader>
+            <ModalBody>
+              <Text textStyle="bodyRegular">Edit waiver</Text>
+              <Textarea
+                my="8px"
+                value={clauseText}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  setClauseText(e.target.value);
+                }}
+                textStyle="bodyRegular"
+                h="300px"
+              />
+              <Checkbox
+                size="md"
+                isChecked={isRequired}
+                colorScheme="green"
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setIsRequired(e.target.checked)
+                }
+              >
+                Mark as a required section
+              </Checkbox>
+            </ModalBody>
+
+            <ModalFooter>
+              <Button mr={3} onClick={onEditClose}>
+                Cancel
+              </Button>
+              <Button colorScheme="green" onClick={onEditConfirm}>
+                Save
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </>
+      <Modal isOpen={isDeleteOpen} onClose={onDeleteClose} isCentered>
+        <ModalOverlay />
         <ModalContent>
-          <ModalHeader><Text textStyle="heading">
-          Edit waiver section
-          </Text></ModalHeader>
           <ModalBody>
-            <Text textStyle="bodyRegular">Edit waiver</Text>
-            <Textarea
-              value={clauseText}
-              onChange={(e : React.ChangeEvent<HTMLTextAreaElement>) => { setClauseText(e.target.value)}}
-              textStyle="bodyRegular"
-              h="300px"
-            />
-            <Checkbox size='md' isChecked={isRequired} colorScheme='green' onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsRequired(e.target.checked)}>
-            Mark as a required section
-            </Checkbox>
+            <Text mt="16px" textStyle="heading">
+              Delete waiver section?
+            </Text>
+
+            <Text mb="28px" mt="12px" textStyle="bodyRegular">
+              Are you sure you want to delete this waiver section?
+            </Text>
+
+            <Text textStyle="bodyBold">Note: this action is irreversible.</Text>
           </ModalBody>
 
           <ModalFooter>
-            <Button mr={3} onClick={onEditClose}>
+            <Button mr={3} onClick={onDeleteClose}>
               Cancel
             </Button>
-            <Button colorScheme='green' onClick={onEditConfirm}> Save </Button>
+            <Button colorScheme="red" onClick={onDeleteConfirm}>
+              Remove
+            </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
-    </>
-    <Modal isOpen={isDeleteOpen} onClose={onDeleteClose}>
-    <ModalOverlay />
-        <ModalContent>
-          <ModalHeader><Text textStyle="heading">
-          Delete waiver section? 
-          </Text></ModalHeader>
-          <ModalBody>
-          <Text textStyle="bodyRegular">Are you sure you want to delete this waiver section?</Text>
-
-         <Text textStyle="bodyBold">Note: this action is irreversible.</Text>
-          </ModalBody>
-
-          <ModalFooter>
-          <Button mr={3} onClick={onDeleteClose}>
-              Cancel
-            </Button>
-            <Button colorScheme='red' onClick={onDeleteConfirm}> Remove </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-
     </>
   );
 };

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
@@ -6,18 +6,23 @@ import WaiverSectionCard from "./WaiverSectionCard";
 
 interface WaiverTabProps {
   clauses: Array<WaiverClause>;
+  onEditWaiverSection: (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => void;
+  onDeleteWaiverSection: (idx: number) => void;
 }
 
-const WaiverTab = ({ clauses }: WaiverTabProps): React.ReactElement => {
+const WaiverTab = ({ clauses, onEditWaiverSection, onDeleteWaiverSection, }: WaiverTabProps): React.ReactElement => {
+
   return (
     <>
-      {clauses.length > 0 ? (
+      {clauses && clauses.length > 0 ? (
         clauses.map((clause, idx) => {
           return (
             <WaiverSectionCard
               key={`waiver_section_card_${idx}`}
               clauseIdx={idx}
               clauseData={clause}
+              onDeleteWaiverSection={onDeleteWaiverSection}
+              onEditWaiverSection={onEditWaiverSection}
             />
           );
         })

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
@@ -6,11 +6,7 @@ import WaiverSectionCard from "./WaiverSectionCard";
 
 interface WaiverTabProps {
   clauses: Array<WaiverClause>;
-  onEditWaiverSection: (
-    clauseText: string,
-    clauseIsRequired: boolean,
-    clauseIdx: number,
-  ) => void;
+  onEditWaiverSection: (clauseData: WaiverClause, clauseIdx: number) => void;
   onDeleteWaiverSection: (idx: number) => void;
 }
 

--- a/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/WaiverTab/index.tsx
@@ -6,12 +6,19 @@ import WaiverSectionCard from "./WaiverSectionCard";
 
 interface WaiverTabProps {
   clauses: Array<WaiverClause>;
-  onEditWaiverSection: (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => void;
+  onEditWaiverSection: (
+    clauseText: string,
+    clauseIsRequired: boolean,
+    clauseIdx: number,
+  ) => void;
   onDeleteWaiverSection: (idx: number) => void;
 }
 
-const WaiverTab = ({ clauses, onEditWaiverSection, onDeleteWaiverSection, }: WaiverTabProps): React.ReactElement => {
-
+const WaiverTab = ({
+  clauses,
+  onEditWaiverSection,
+  onDeleteWaiverSection,
+}: WaiverTabProps): React.ReactElement => {
   return (
     <>
       {clauses && clauses.length > 0 ? (

--- a/frontend/src/components/pages/GlobalForms/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/index.tsx
@@ -79,14 +79,13 @@ const GlobalFormsPage = (): React.ReactElement => {
   };
 
   const onEditWaiverSection = async (
-    clauseText: string,
-    clauseIsRequired: boolean,
+    clauseData: WaiverClause,
     clauseIdx: number,
   ) => {
     const curClauses = waiverClauses;
     const clauseToEdit = curClauses[clauseIdx];
-    clauseToEdit.text = clauseText;
-    clauseToEdit.required = clauseIsRequired;
+    clauseToEdit.text = clauseData.text;
+    clauseToEdit.required = clauseData.required;
 
     const editWaiverRequest: UpdateWaiverRequest = { clauses: curClauses };
 

--- a/frontend/src/components/pages/GlobalForms/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/index.tsx
@@ -57,6 +57,7 @@ const GlobalFormsPage = (): React.ReactElement => {
     );
 
     if (updatedWaiver.clauses) {
+
       setWaiverClauses(updatedWaiver.clauses);
 
       const newSectionCharCode: number = updatedWaiver.clauses.length + 64;
@@ -77,6 +78,70 @@ const GlobalFormsPage = (): React.ReactElement => {
       });
     }
   };
+
+  const onEditWaiverSection = async (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => {
+    const curClauses = waiverClauses;
+    const clauseToEdit = curClauses[clauseIdx];
+    clauseToEdit.text = clauseText;
+    clauseToEdit.required = clauseIsRequired;
+
+    const editWaiverRequest: UpdateWaiverRequest = { clauses: curClauses };
+
+    const updatedWaiver: UpdateWaiverRequest = await AdminAPIClient.updateWaiver(
+      editWaiverRequest,
+    );
+
+    if (updatedWaiver.clauses) {
+      setWaiverClauses(updatedWaiver.clauses);
+
+      const deletedWaiverCode: string = String.fromCharCode(clauseIdx);
+
+      toast({
+        description: `Section ${deletedWaiverCode} has been updated`,
+        status: "success",
+        variant: "subtle",
+        duration: 3000,
+      });
+    } else {
+      toast({
+        description: `Section could not be updated`,
+        status: "error",
+        variant: "subtle",
+        duration: 3000,
+      });
+    }
+  }
+
+  const onDeleteWaiverSection = async (idx: number) => {
+    const curClauses = waiverClauses;
+    curClauses.splice(idx, 1);
+
+    const deleteWaiverRequest: UpdateWaiverRequest = { clauses: curClauses };
+
+    const updatedWaiver: UpdateWaiverRequest = await AdminAPIClient.updateWaiver(
+      deleteWaiverRequest,
+    );
+
+    if (updatedWaiver.clauses) {
+      setWaiverClauses(updatedWaiver.clauses);
+
+      const deletedWaiverCode: string = String.fromCharCode(idx);
+
+      toast({
+        description: `Section ${deletedWaiverCode} has been deleted`,
+        status: "success",
+        variant: "subtle",
+        duration: 3000,
+      });
+    } else {
+      toast({
+        description: `Section could not be deleted`,
+        status: "error",
+        variant: "subtle",
+        duration: 3000,
+      });
+    }
+  }
 
   return (
     <>
@@ -110,7 +175,7 @@ const GlobalFormsPage = (): React.ReactElement => {
                 <RegistrationFormTemplateTab />
               </TabPanel>
               <TabPanel>
-                <WaiverTab clauses={waiverClauses} />
+                <WaiverTab clauses={waiverClauses} onEditWaiverSection={onEditWaiverSection} onDeleteWaiverSection={onDeleteWaiverSection}/>
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/frontend/src/components/pages/GlobalForms/index.tsx
+++ b/frontend/src/components/pages/GlobalForms/index.tsx
@@ -57,7 +57,6 @@ const GlobalFormsPage = (): React.ReactElement => {
     );
 
     if (updatedWaiver.clauses) {
-
       setWaiverClauses(updatedWaiver.clauses);
 
       const newSectionCharCode: number = updatedWaiver.clauses.length + 64;
@@ -79,7 +78,11 @@ const GlobalFormsPage = (): React.ReactElement => {
     }
   };
 
-  const onEditWaiverSection = async (clauseText: string, clauseIsRequired: boolean, clauseIdx: number) => {
+  const onEditWaiverSection = async (
+    clauseText: string,
+    clauseIsRequired: boolean,
+    clauseIdx: number,
+  ) => {
     const curClauses = waiverClauses;
     const clauseToEdit = curClauses[clauseIdx];
     clauseToEdit.text = clauseText;
@@ -94,10 +97,10 @@ const GlobalFormsPage = (): React.ReactElement => {
     if (updatedWaiver.clauses) {
       setWaiverClauses(updatedWaiver.clauses);
 
-      const deletedWaiverCode: string = String.fromCharCode(clauseIdx);
+      const waiverCode: string = String.fromCharCode(clauseIdx + 65);
 
       toast({
-        description: `Section ${deletedWaiverCode} has been updated`,
+        description: `Section ${waiverCode} has been updated`,
         status: "success",
         variant: "subtle",
         duration: 3000,
@@ -110,7 +113,7 @@ const GlobalFormsPage = (): React.ReactElement => {
         duration: 3000,
       });
     }
-  }
+  };
 
   const onDeleteWaiverSection = async (idx: number) => {
     const curClauses = waiverClauses;
@@ -125,7 +128,7 @@ const GlobalFormsPage = (): React.ReactElement => {
     if (updatedWaiver.clauses) {
       setWaiverClauses(updatedWaiver.clauses);
 
-      const deletedWaiverCode: string = String.fromCharCode(idx);
+      const deletedWaiverCode: string = String.fromCharCode(idx + 65);
 
       toast({
         description: `Section ${deletedWaiverCode} has been deleted`,
@@ -141,7 +144,7 @@ const GlobalFormsPage = (): React.ReactElement => {
         duration: 3000,
       });
     }
-  }
+  };
 
   return (
     <>
@@ -175,7 +178,11 @@ const GlobalFormsPage = (): React.ReactElement => {
                 <RegistrationFormTemplateTab />
               </TabPanel>
               <TabPanel>
-                <WaiverTab clauses={waiverClauses} onEditWaiverSection={onEditWaiverSection} onDeleteWaiverSection={onDeleteWaiverSection}/>
+                <WaiverTab
+                  clauses={waiverClauses}
+                  onEditWaiverSection={onEditWaiverSection}
+                  onDeleteWaiverSection={onDeleteWaiverSection}
+                />
               </TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Edit + Delete Front end ](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=b4dbb43b89144b8f8b4d54ba04725a0e&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* I added two modals for the edit and delete confirmation in the WaiverSectionCard.ts file
* I added two functions onDeleteWaiverSection and onEditWaiverSection in the GlobalForms/index.ts file and passed these down so that we could call the API at the highest level instead of changing state multiple times


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Try editing a section -> the section should change and there should be a success toast
2. Try deleting a section -> the section should disappear and there should be a success toast


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I'm not sure if I'm handling state the best way in the WaiverSectionCard.ts file, I went back and forth with splitting up the modals into multiple files but ended up thinking it would be nice if everything related to one section was in the same file


## Checklist
- [ x] My PR name is descriptive and in imperative tense
- [x ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ x] I have run the appropriate linter(s)
- [ x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
