### PR TITLE
Edit/Remove formQuestion from formTemplate backend

### DIFF
--- a/backend/typescript/middlewares/validators/adminValidators.ts
+++ b/backend/typescript/middlewares/validators/adminValidators.ts
@@ -60,3 +60,17 @@ export const formTemplateAddQuestionValidator = async (
   }
   return next();
 };
+
+export const formTemplateRemoveQuestionValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (
+    !req.params.formQuestionId ||
+    !validatePrimitive(req.params.formQuestionId, "string")
+  ) {
+    return res.status(400).send("formQuestionId param must be a string");
+  }
+  return next();
+};

--- a/backend/typescript/middlewares/validators/adminValidators.ts
+++ b/backend/typescript/middlewares/validators/adminValidators.ts
@@ -74,3 +74,25 @@ export const formTemplateRemoveQuestionValidator = async (
   }
   return next();
 };
+
+export const formTemplateEditQuestionValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (
+    !req.params.oldQuestionId ||
+    !validatePrimitive(req.params.oldQuestionId, "string")
+  ) {
+    return res.status(400).send("oldQuestionId param must be a string");
+  }
+
+  if (
+    !req.body.newFormQuestion ||
+    !validateFormQuestion(req.body.newFormQuestion)
+  ) {
+    return res.status(400).send("new form question details invalid");
+  }
+
+  return next();
+};

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -100,6 +100,7 @@ adminRouter.patch(
   },
 );
 
+// ROLES: Admin
 adminRouter.patch(
   "/formTemplate/formQuestion/:oldQuestionId",
   formTemplateEditQuestionValidator,

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -7,6 +7,7 @@ import {
   waiverUpdateValidator,
   formTemplateUpdateValidator,
   formTemplateAddQuestionValidator,
+  formTemplateRemoveQuestionValidator,
 } from "../middlewares/validators/adminValidators";
 import { isAuthorizedByRole } from "../middlewares/auth";
 
@@ -60,6 +61,21 @@ adminRouter.get("/formTemplate", async (req, res) => {
     res.status(500).json({ error: getErrorMessage(error) });
   }
 });
+
+// ROLES: Admin
+adminRouter.delete(
+  "/formTemplate/formQuestion/:formQuestionId",
+  formTemplateRemoveQuestionValidator,
+  isAuthorizedByRole(new Set(["Admin"])),
+  async (req, res) => {
+    try {
+      await adminService.removeQuestionFromTemplate(req.params.formQuestionId);
+      res.status(200).json(req.params.formQuestionId);
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  },
+);
 
 // ROLES: Admin
 adminRouter.patch(

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -8,6 +8,7 @@ import {
   formTemplateUpdateValidator,
   formTemplateAddQuestionValidator,
   formTemplateRemoveQuestionValidator,
+  formTemplateEditQuestionValidator,
 } from "../middlewares/validators/adminValidators";
 import { isAuthorizedByRole } from "../middlewares/auth";
 
@@ -93,6 +94,23 @@ adminRouter.patch(
         type: req.body.formQuestion.type,
       });
       res.status(200).json(newQuestion);
+    } catch (error: unknown) {
+      res.status(500).json({ error: getErrorMessage(error) });
+    }
+  },
+);
+
+adminRouter.patch(
+  "/formTemplate/formQuestion/:oldQuestionId",
+  formTemplateEditQuestionValidator,
+  isAuthorizedByRole(new Set(["Admin"])),
+  async (req, res) => {
+    try {
+      const isSuccess = await adminService.editQuestionInTemplate(
+        req.params.oldQuestionId,
+        req.body.newFormQuestion,
+      );
+      res.status(200).json(isSuccess);
     } catch (error: unknown) {
       res.status(500).json({ error: getErrorMessage(error) });
     }

--- a/backend/typescript/rest/adminRoutes.ts
+++ b/backend/typescript/rest/adminRoutes.ts
@@ -71,7 +71,7 @@ adminRouter.delete(
   async (req, res) => {
     try {
       await adminService.removeQuestionFromTemplate(req.params.formQuestionId);
-      res.status(200).json(req.params.formQuestionId);
+      res.status(204).json();
     } catch (error: unknown) {
       res.status(500).json({ error: getErrorMessage(error) });
     }

--- a/backend/typescript/services/implementations/adminService.ts
+++ b/backend/typescript/services/implementations/adminService.ts
@@ -163,6 +163,27 @@ class AdminService implements IAdminService {
       await session.endSession();
     }
   }
+
+  async removeQuestionFromTemplate(formQuestionId: string): Promise<boolean> {
+    try {
+      await MgFormTemplate.updateOne(
+        {},
+        {
+          $pull: {
+            formQuestions: formQuestionId,
+          },
+        },
+      );
+      return true;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to remove form question from form template. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default AdminService;

--- a/backend/typescript/services/implementations/adminService.ts
+++ b/backend/typescript/services/implementations/adminService.ts
@@ -202,7 +202,7 @@ class AdminService implements IAdminService {
 
       if (!formTemplate) {
         throw new Error(
-          "Failed to retrieve the form template with that question",
+          `Failed to retrieve the form template, no template with question of id: ${oldQuestionId}`,
         );
       }
 

--- a/backend/typescript/services/interfaces/adminService.ts
+++ b/backend/typescript/services/interfaces/adminService.ts
@@ -44,6 +44,15 @@ interface IAdminService {
   addQuestionToTemplate(
     formQuestion: CreateFormQuestionDTO,
   ): Promise<FormQuestionDTO>;
+
+  /**
+   * Removes a question from the form template
+   * NOTE: does NOT delete the formQuestion as old camps may have references to this formQuestion
+   * @returns true if successfully removed the formQuestion, false otherwise
+   * @param formQuestionId is the objectID of the form question to be removed from the template
+   * @throws Error if removing fails (db query to remove fails etc.)
+   */
+  removeQuestionFromTemplate(formQuestionId: string): Promise<boolean>;
 }
 
 export default IAdminService;

--- a/backend/typescript/services/interfaces/adminService.ts
+++ b/backend/typescript/services/interfaces/adminService.ts
@@ -53,6 +53,20 @@ interface IAdminService {
    * @throws Error if removing fails (db query to remove fails etc.)
    */
   removeQuestionFromTemplate(formQuestionId: string): Promise<boolean>;
+
+  /**
+   * Edits a question in the form template
+   * NOTE: does NOT edit the old question as older camps still use the old version of the question
+   *       creates a NEW question with the edited values and REPLACES old question in the template
+   * @returns true if successfully edited the template, false otherwise
+   * @param oldQuestionId is the objectID as string of the form question to be removed from the template
+   * @param newformQuestion is the data for the edited form question
+   * @throws Error if editing fails (db query to create / remove fails etc.)
+   */
+  editQuestionInTemplate(
+    oldQuestionId: string,
+    newformQuestion: CreateFormQuestionDTO,
+  ): Promise<boolean>;
 }
 
 export default IAdminService;

--- a/backend/typescript/services/interfaces/adminService.ts
+++ b/backend/typescript/services/interfaces/adminService.ts
@@ -56,8 +56,10 @@ interface IAdminService {
 
   /**
    * Edits a question in the form template
-   * NOTE: does NOT edit the old question as older camps still use the old version of the question
-   *       creates a NEW question with the edited values and REPLACES old question in the template
+   * NOTE: Form template includes a list of form question ids referencing documents in the formQuestion collection.
+   *       This implementation does NOT edit the old question object, as older camps should keep reference to the pre-edited version.
+   *       New camps should refer to the "updated" question, which is a new question with the "edited" values;
+   *       this question replaces the old question in the template.
    * @returns true if successfully edited the template, false otherwise
    * @param oldQuestionId is the objectID as string of the form question to be removed from the template
    * @param newformQuestion is the data for the edited form question


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Form Management: Edit/remove question in form template](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=792e8a8c96954713a7399446547c0fad&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* made a new endpoint for editing a question in the form template
* made a new function in the admin service to "edit" the form question


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Make a PATCH request to `/admin/formTemplate/formQuestion/:oldQuestionId` <-- get this form mongoDB 
2. use postman with the following body:
```
{
    "newFormQuestion" : {
        "category": "CampSpecific",
        "type" : "MultipleChoice",
        "question": "Can the camper swim?",
        "required" : false,
        "description" : "We will not have life guards on duty",
        "options": ["Yes", "No"]
    }
}
```
3. You should get `true` if the oldQuestionId you provided was in the template

4. Make sure to test error paths (no auth, invalid body, params)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* testing
* use of transactions?


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
