### PR TITLE
Fix: Removes infinite loop in getCamps request on Camp List table

### DIFF
--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -65,7 +65,7 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
     };
 
     getCamps();
-  }, [year, camps]);
+  }, [year]);
 
   const tableData = React.useMemo(() => {
     let filteredCamps = camps;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
Spontaneous bug fix for inifinite loop of getCamps request


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the camp list page and go to inspect element -> network tab 
2. Verify that the request to get all camps is not being repeatedly called


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
