### PR TITLE
Create camp list preview drawer

### DIFF
--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -34,7 +34,11 @@ import ViewCamperModal from "../ViewCamperModal/index";
 import { FormQuestion } from "../../../../types/CampsTypes";
 import RemoveCamperModal from "../RemoveCamperModal/index";
 
-const ExportButton = ({generateCsv}: {generateCsv: () => void}): JSX.Element => {  
+const ExportButton = ({
+  generateCsv,
+}: {
+  generateCsv: () => void;
+}): JSX.Element => {
   return (
     <Box>
       <Button
@@ -185,7 +189,7 @@ const CampersTable = ({
                 </Tag>
               );
             })}
-            <ExportButton generateCsv={generateCsv}/>
+            <ExportButton generateCsv={generateCsv} />
           </HStack>
 
           <Table

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -17,7 +17,7 @@ const CampersTables = ({
   campSession,
   formQuestions,
   handleRefetch,
-  generateCsv
+  generateCsv,
 }: CampersTablesProps): JSX.Element => {
   return (
     <Box>

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -186,9 +186,17 @@ const CampOverviewPage = (): JSX.Element => {
   };
 
   const generateCsv = async () => {
-    const csvResponse = await CampsAPIClient.getCampSessionCsv(camp.campSessions[currentCampSession].id);
+    const csvResponse = await CampsAPIClient.getCampSessionCsv(
+      camp.campSessions[currentCampSession].id,
+    );
     if (csvResponse !== "ERROR") {
-      downloadCSV(csvResponse, generateCSVName(camp.location.city, camp.campSessions[currentCampSession].dates[0]));
+      downloadCSV(
+        csvResponse,
+        generateCSVName(
+          camp.location.city,
+          camp.campSessions[currentCampSession].dates[0],
+        ),
+      );
     } else {
       toast({
         description: `An error occurred while exporting the CSV. Please try again.`,
@@ -197,7 +205,7 @@ const CampOverviewPage = (): JSX.Element => {
         duration: 3000,
       });
     }
-  }
+  };
 
   return (
     <Container

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -65,7 +65,10 @@ const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampD
   React.useEffect(() => {
     const getCamps = async () => {
       const res = await CampsAPIClient.getAllCamps(year);
-      if (res){ setCamps(res); setCampDrawerInfo(res[0])}
+      if (res) {
+        setCamps(res);
+        setCampDrawerInfo(res[0]);
+      }
     };
 
     getCamps();
@@ -213,11 +216,12 @@ const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampD
             >
               <Td
                 cursor="pointer"
-                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+                onClick={() => {
+                  onDrawerOpen();
+                  setCampDrawerInfo(camp);
+                }}
               >
-                <Text 
-                  textStyle="bodyBold"
-                >{camp.name}</Text>
+                <Text textStyle="bodyBold">{camp.name}</Text>
                 <Text textStyle="bodyRegular">
                   {locationString(camp.location)}
                 </Text>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -25,7 +25,7 @@ import {
   useDisclosure,
   useToast,
 } from "@chakra-ui/react";
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { CampResponse, CampStatus } from "../../../types/CampsTypes";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
 import {
@@ -38,10 +38,12 @@ import DeleteCampConfirmationModel from "./DeleteCampConfirmationModel";
 
 interface CampsTableProps {
   year: number;
+  onDrawerOpen: ()=>void
+  setCampDrawerInfo: Dispatch<SetStateAction<CampResponse | undefined>>
 }
 
 const CampsTable = (props: CampsTableProps): JSX.Element => {
-  const { year } = props;
+  const { year, onDrawerOpen, setCampDrawerInfo } = props;
 
   const filterOptions = [
     CampStatus.PUBLISHED,
@@ -62,7 +64,7 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
   React.useEffect(() => {
     const getCamps = async () => {
       const res = await CampsAPIClient.getAllCamps(year);
-      if (res) setCamps(res);
+      if (res){ setCamps(res); setCampDrawerInfo(res[0])}
     };
 
     getCamps();
@@ -203,8 +205,13 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
         <Tbody>
           {tableData.map((camp, key) => (
             <Tr key={key}>
-              <Td>
-                <Text textStyle="bodyBold">{camp.name}</Text>
+              <Td
+                cursor="pointer"
+                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+              >
+                <Text 
+                  textStyle="bodyBold"
+                >{camp.name}</Text>
                 <Text textStyle="bodyRegular">
                   {locationString(camp.location)}
                 </Text>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -37,15 +37,20 @@ import CampStatusLabel from "./CampStatusLabel";
 import DeleteCampConfirmationModel from "./DeleteCampConfirmationModel";
 
 type CampsTableProps = {
-  year: number
-  isDrawerOpen: boolean
-  onDrawerOpen: ()=>void
-  campDrawerInfo: CampResponse | undefined
-  setCampDrawerInfo: Dispatch<SetStateAction<CampResponse | undefined>>
-}
+  year: number;
+  isDrawerOpen: boolean;
+  onDrawerOpen: () => void;
+  campDrawerInfo: CampResponse | undefined;
+  setCampDrawerInfo: Dispatch<SetStateAction<CampResponse | undefined>>;
+};
 
-const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampDrawerInfo }: CampsTableProps): JSX.Element => {
-
+const CampsTable = ({
+  year,
+  isDrawerOpen,
+  onDrawerOpen,
+  campDrawerInfo,
+  setCampDrawerInfo,
+}: CampsTableProps): JSX.Element => {
   const filterOptions = [
     CampStatus.PUBLISHED,
     CampStatus.DRAFT,
@@ -207,12 +212,16 @@ const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampD
         </Thead>
         <Tbody>
           {tableData.map((camp, key) => (
-            <Tr 
+            <Tr
               key={key}
               _hover={{
-                background: "background.grey.100"
+                background: "background.grey.100",
               }}
-              background={isDrawerOpen && camp === campDrawerInfo?"background.grey.100":"background.white.100"}
+              background={
+                isDrawerOpen && camp === campDrawerInfo
+                  ? "background.grey.100"
+                  : "background.white.100"
+              }
             >
               <Td
                 cursor="pointer"
@@ -228,7 +237,10 @@ const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampD
               </Td>
               <Td
                 cursor="pointer"
-                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+                onClick={() => {
+                  onDrawerOpen();
+                  setCampDrawerInfo(camp);
+                }}
               >
                 {camp.campSessions.length > 0
                   ? getFormattedCampDateRange(
@@ -241,7 +253,10 @@ const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampD
                 padding="0px"
                 mr="px"
                 cursor="pointer"
-                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+                onClick={() => {
+                  onDrawerOpen();
+                  setCampDrawerInfo(camp);
+                }}
               >
                 <CampStatusLabel status={getCampStatus(camp)} />
               </Td>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -36,14 +36,15 @@ import {
 import CampStatusLabel from "./CampStatusLabel";
 import DeleteCampConfirmationModel from "./DeleteCampConfirmationModel";
 
-interface CampsTableProps {
-  year: number;
+type CampsTableProps = {
+  year: number
+  isDrawerOpen: boolean
   onDrawerOpen: ()=>void
+  campDrawerInfo: CampResponse | undefined
   setCampDrawerInfo: Dispatch<SetStateAction<CampResponse | undefined>>
 }
 
-const CampsTable = (props: CampsTableProps): JSX.Element => {
-  const { year, onDrawerOpen, setCampDrawerInfo } = props;
+const CampsTable = ({ year, isDrawerOpen, onDrawerOpen, campDrawerInfo, setCampDrawerInfo }: CampsTableProps): JSX.Element => {
 
   const filterOptions = [
     CampStatus.PUBLISHED,
@@ -155,7 +156,7 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
         py="20px"
         maxWidth="100vw"
         backgroundColor="background.grey.100"
-        borderRadius="20px"
+        borderRadius="20px 20px 0 0"
       >
         <HStack spacing={12}>
           <InputGroup>
@@ -189,10 +190,9 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
         </HStack>
       </Container>
       <Table
-        background="background.white.100"
         variant="simple"
         colorScheme="blackAlpha"
-        style={{ borderCollapse: "separate" }}
+        background="background.white.100"
       >
         <Thead>
           <Tr>
@@ -204,7 +204,13 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
         </Thead>
         <Tbody>
           {tableData.map((camp, key) => (
-            <Tr key={key}>
+            <Tr 
+              key={key}
+              _hover={{
+                background: "background.grey.100"
+              }}
+              background={isDrawerOpen && camp === campDrawerInfo?"background.grey.100":"background.white.100"}
+            >
               <Td
                 cursor="pointer"
                 onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
@@ -216,7 +222,10 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
                   {locationString(camp.location)}
                 </Text>
               </Td>
-              <Td>
+              <Td
+                cursor="pointer"
+                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+              >
                 {camp.campSessions.length > 0
                   ? getFormattedCampDateRange(
                       camp.campSessions[0].dates,
@@ -224,7 +233,12 @@ const CampsTable = (props: CampsTableProps): JSX.Element => {
                     )
                   : ""}
               </Td>
-              <Td padding="0px" mr="px">
+              <Td
+                padding="0px"
+                mr="px"
+                cursor="pointer"
+                onClick={() => {onDrawerOpen(); setCampDrawerInfo(camp);}}
+              >
                 <CampStatusLabel status={getCampStatus(camp)} />
               </Td>
               <Td>

--- a/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
@@ -1,0 +1,197 @@
+import { Box, Button, Text, Flex, Tag } from '@chakra-ui/react'
+import React from 'react'
+import CampStatusLabel from './CampStatusLabel'
+import {
+  getCampStatus, locationString, getFormattedDateString
+} from "../../../utils/CampUtils";
+import { CampResponse, CampSession } from '../../../types/CampsTypes';
+
+interface IDrawer{
+    isOpen:boolean,
+    onClose: ()=>void,
+    camp:CampResponse | undefined,
+
+}
+
+const PreviewCampDrawer = ({isOpen, onClose, camp}:IDrawer) => {
+  return camp?(
+    
+    <Flex
+        bg="background.white.100"
+        w="500px"
+        h="calc(100vh - 68px)"
+        position="absolute"
+        pos="fixed"
+        right={isOpen?"0px":"-500px"}
+        transition="right 0.5s"
+        borderWidth= "1px 0 1px 1px"
+        borderColor="border.secondary.100"
+        flexDirection="column"
+    >
+      <Box
+        paddingRight="32px"
+        paddingLeft="32px"
+      >
+        <Text 
+          onClick={onClose}
+          color="#A3AEBE"
+          textDecoration="underline"
+          marginTop="32px"
+          textAlign="right"
+          textStyle="xSmallBold"
+          cursor="pointer"
+        >
+          Close
+        </Text>
+        <Text 
+          textStyle="displayMediumBold"
+          marginTop="20px"
+        >
+          {camp.name}
+        </Text>
+        
+        <Text textStyle="displayMediumRegular">
+            {locationString(camp.location)}
+        </Text>
+
+        <Box
+          marginTop="12px"
+          w="fit-content"
+        >
+          {camp?<CampStatusLabel status={getCampStatus(camp)} />:""}
+        </Box>
+        <Box
+          marginTop="20px"
+          padding="16px 32px"
+          borderRadius="5px"
+          borderWidth="2px"
+          borderColor="border.input.100"
+        >
+          <Text textStyle="buttonSemiBold">
+            Daily Camp Fee:{" "} 
+            <Text as="span" textStyle="buttonRegular">
+              ${camp.fee} per day
+            </Text>
+          </Text>
+          <Text textStyle="buttonSemiBold">
+            Age Range:{" "}
+            <Text as="span" textStyle="buttonRegular">
+              {camp.ageLower} to {camp.ageUpper}
+            </Text>
+          </Text>
+
+        </Box>
+        <Box
+          margin="20px 0"
+        >
+          <Button
+            marginRight="20px"
+            aria-label="View Camp"
+            border="1px"
+            borderRadius="5px"
+            color="primary.green.100"
+            bg="white"
+            borderColor="primary.green.100"
+            minWidth="-webkit-fit-content"
+          >
+            View Camp
+          </Button>
+          <Button
+            marginRight="20px"
+            aria-label="View Camp"
+            border="1px"
+            borderRadius="5px"
+            color="secondary.critical.100"
+            bg="white"
+            borderColor="secondary.critical.100"
+            minWidth="-webkit-fit-content"
+          >
+            Delete Camp
+          </Button>
+        </Box>
+      </Box>
+
+      <Flex
+        bg="background.grey.100"
+        paddingRight="32px"
+        paddingLeft="32px"
+        borderTop= "1px"
+        borderColor="border.secondary.100"
+        overflowY="auto"
+        flexGrow="1"
+        flexDirection="column"
+        sx={{
+          '&::-webkit-scrollbar': {
+            backgroundColor: `white`,
+          },
+          '&::-webkit-scrollbar-thumb': {
+            width: '8px',
+            borderRadius: '12px',
+            backgroundColor: `#A3AEBE`,
+          },
+          '&::-webkit-scrollbar-button': {
+            display: `none`,
+          },
+        }}
+      >
+        <Text
+          textStyle="buttonSemiBold"
+          marginTop="24px"
+          marginBottom="20px"
+        >
+          {camp.campSessions.length} Session{camp.campSessions.length!==1?"s":""}
+        </Text>
+        
+        {camp.campSessions.map((session:CampSession, key:number) => {
+          return(
+            <Box
+              marginBottom="12px"
+              key={key}
+            >
+              <Flex>
+                <>
+                  <Text textStyle="subHeading" marginRight="12px">
+                    Session {key+1}
+                  </Text>
+                  {
+                    (() => {
+                        if (getCampStatus(camp) === "Published"){
+                          return session.campers.length >= session.capacity ? (
+                            <Tag colorScheme="orange" borderRadius="full" size="sm">
+                              Session full
+                            </Tag>
+                          ) : (
+                            <Tag colorScheme="green" borderRadius="full" size="sm">
+                              Session available
+                            </Tag>
+                          )
+                        }
+                        return ""
+                    })()
+                  }
+                </>
+              </Flex>
+              <Text textStyle="subHeading">
+                {getFormattedDateString(session.dates)}
+              </Text> 
+              <Text textStyle="caption">
+                Registrations (
+                  <Text
+                    as="span"
+                    textStyle={getCampStatus(camp) === "Published" && session.campers.length >= session.capacity?"subHeading":"caption"}
+                  >
+                    {session.campers.length}/{session.capacity}
+                  </Text>
+                ) | Waitlist ({session.waitlist.length})
+              </Text>
+            </Box>
+          )
+          })}
+
+      </Flex>
+    </Flex>
+    
+  ):<></>
+}
+
+export default PreviewCampDrawer

--- a/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { FontWeights } from "../../../theme/textStyles"
 import CampStatusLabel from './CampStatusLabel'
 import {
-  getCampStatus, locationString, getFormattedDateString
+  getCampStatus,
+  locationString,
 } from "../../../utils/CampUtils";
 import { CampResponse, CampSession } from '../../../types/CampsTypes';
 import PreviewModalSessionRow from './PreviewModalSessionRow';
@@ -19,22 +20,19 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
   return camp?(
     
     <Flex
-        bg="background.white.100"
-        w="500px"
-        h="calc(100vh - 68px)"
-        position="absolute"
-        pos="fixed"
-        right={isOpen?"0px":"-500px"}
-        transition="right 0.5s"
-        borderWidth= "1px 0 1px 1px"
-        borderColor="border.secondary.100"
-        flexDirection="column"
+      bg="background.white.100"
+      w="500px"
+      h="calc(100vh - 68px)"
+      position="absolute"
+      pos="fixed"
+      right={isOpen ? "0px" : "-500px"}
+      transition="right 0.5s"
+      borderWidth="1px 0 1px 1px"
+      borderColor="border.secondary.100"
+      flexDirection="column"
     >
-      <Box
-        paddingRight="32px"
-        paddingLeft="32px"
-      >
-        <Text 
+      <Box paddingRight="32px" paddingLeft="32px">
+        <Text
           onClick={onClose}
           color="#A3AEBE"
           textDecoration="underline"
@@ -45,10 +43,7 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
         >
           Close
         </Text>
-        <Text 
-          textStyle="displayMediumBold"
-          marginTop="20px"
-        >
+        <Text textStyle="displayMediumBold" marginTop="20px">
           {camp.name}
         </Text>
         
@@ -56,11 +51,8 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
             {locationString(camp.location)}
         </Text>
 
-        <Box
-          marginTop="12px"
-          w="fit-content"
-        >
-          {camp?<CampStatusLabel status={getCampStatus(camp)} />:""}
+        <Box marginTop="12px" w="fit-content">
+          {camp ? <CampStatusLabel status={getCampStatus(camp)} /> : ""}
         </Box>
         <Box
           marginTop="20px"
@@ -70,7 +62,7 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
           borderColor="border.input.100"
         >
           <Text textStyle="buttonSemiBold">
-            Daily Camp Fee:{" "} 
+            Daily Camp Fee:{" "}
             <Text as="span" textStyle="buttonRegular">
               ${camp.fee} per day
             </Text>
@@ -81,11 +73,8 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
               {camp.ageLower} to {camp.ageUpper}
             </Text>
           </Text>
-
         </Box>
-        <Box
-          margin="20px 0"
-        >
+        <Box margin="20px 0">
           <Button
             marginRight="20px"
             aria-label="View Camp"
@@ -117,31 +106,28 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
         bg="background.grey.100"
         paddingRight="32px"
         paddingLeft="32px"
-        borderTop= "1px"
+        borderTop="1px"
         borderColor="border.secondary.100"
         overflowY="auto"
         flexGrow="1"
         flexDirection="column"
         sx={{
-          '&::-webkit-scrollbar': {
+          "&::-webkit-scrollbar": {
             backgroundColor: `white`,
           },
-          '&::-webkit-scrollbar-thumb': {
-            width: '8px',
-            borderRadius: '12px',
+          "&::-webkit-scrollbar-thumb": {
+            width: "8px",
+            borderRadius: "12px",
             backgroundColor: `#A3AEBE`,
           },
-          '&::-webkit-scrollbar-button': {
+          "&::-webkit-scrollbar-button": {
             display: `none`,
           },
         }}
       >
-        <Text
-          textStyle="buttonSemiBold"
-          marginTop="24px"
-          marginBottom="20px"
-        >
-          {camp.campSessions.length} Session{camp.campSessions.length!==1?"s":""}
+        <Text textStyle="buttonSemiBold" marginTop="24px" marginBottom="20px">
+          {camp.campSessions.length} Session
+          {camp.campSessions.length !== 1 ? "s" : ""}
         </Text>
         
         {camp.campSessions.map((session:CampSession, key:number) => {
@@ -152,8 +138,9 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
 
       </Flex>
     </Flex>
-    
-  ):<></>
-}
+  ) : (
+    <></>
+  );
+};
 
-export default PreviewCampDrawer
+export default PreviewCampDrawer;

--- a/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
@@ -1,24 +1,23 @@
-import { Box, Button, Text, Flex, Tag } from '@chakra-ui/react'
-import React from 'react'
-import { FontWeights } from "../../../theme/textStyles"
-import CampStatusLabel from './CampStatusLabel'
-import {
-  getCampStatus,
-  locationString,
-} from "../../../utils/CampUtils";
-import { CampResponse, CampSession } from '../../../types/CampsTypes';
-import PreviewModalSessionRow from './PreviewModalSessionRow';
+import { Box, Button, Text, Flex, Tag } from "@chakra-ui/react";
+import React from "react";
+import { FontWeights } from "../../../theme/textStyles";
+import CampStatusLabel from "./CampStatusLabel";
+import { getCampStatus, locationString } from "../../../utils/CampUtils";
+import { CampResponse, CampSession } from "../../../types/CampsTypes";
+import PreviewModalSessionRow from "./PreviewModalSessionRow";
 
 type CampDrawerProps = {
-    isOpen:boolean,
-    onClose: ()=>void,
-    camp:CampResponse | undefined,
-}
+  isOpen: boolean;
+  onClose: () => void;
+  camp: CampResponse | undefined;
+};
 
-const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Element => {
-
-  return camp?(
-    
+const PreviewCampDrawer = ({
+  isOpen,
+  onClose,
+  camp,
+}: CampDrawerProps): JSX.Element => {
+  return camp ? (
     <Flex
       bg="background.white.100"
       w="500px"
@@ -46,9 +45,9 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
         <Text textStyle="displayMediumBold" marginTop="20px">
           {camp.name}
         </Text>
-        
-        <Text textStyle="heading" fontWeight= {FontWeights.REGULAR}>
-            {locationString(camp.location)}
+
+        <Text textStyle="heading" fontWeight={FontWeights.REGULAR}>
+          {locationString(camp.location)}
         </Text>
 
         <Box marginTop="12px" w="fit-content">
@@ -129,13 +128,17 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Elemen
           {camp.campSessions.length} Session
           {camp.campSessions.length !== 1 ? "s" : ""}
         </Text>
-        
-        {camp.campSessions.map((session:CampSession, key:number) => {
-          return(
-              <PreviewModalSessionRow key={key} sessionNum={key+1} status={getCampStatus(camp)} session={session}/>
-          )
-          })}
 
+        {camp.campSessions.map((session: CampSession, key: number) => {
+          return (
+            <PreviewModalSessionRow
+              key={key}
+              sessionNum={key + 1}
+              status={getCampStatus(camp)}
+              session={session}
+            />
+          );
+        })}
       </Flex>
     </Flex>
   ) : (

--- a/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewCampDrawer.tsx
@@ -1,19 +1,21 @@
 import { Box, Button, Text, Flex, Tag } from '@chakra-ui/react'
 import React from 'react'
+import { FontWeights } from "../../../theme/textStyles"
 import CampStatusLabel from './CampStatusLabel'
 import {
   getCampStatus, locationString, getFormattedDateString
 } from "../../../utils/CampUtils";
 import { CampResponse, CampSession } from '../../../types/CampsTypes';
+import PreviewModalSessionRow from './PreviewModalSessionRow';
 
-interface IDrawer{
+type CampDrawerProps = {
     isOpen:boolean,
     onClose: ()=>void,
     camp:CampResponse | undefined,
-
 }
 
-const PreviewCampDrawer = ({isOpen, onClose, camp}:IDrawer) => {
+const PreviewCampDrawer = ({isOpen, onClose, camp}: CampDrawerProps): JSX.Element => {
+
   return camp?(
     
     <Flex
@@ -50,7 +52,7 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}:IDrawer) => {
           {camp.name}
         </Text>
         
-        <Text textStyle="displayMediumRegular">
+        <Text textStyle="heading" fontWeight= {FontWeights.REGULAR}>
             {locationString(camp.location)}
         </Text>
 
@@ -144,47 +146,7 @@ const PreviewCampDrawer = ({isOpen, onClose, camp}:IDrawer) => {
         
         {camp.campSessions.map((session:CampSession, key:number) => {
           return(
-            <Box
-              marginBottom="12px"
-              key={key}
-            >
-              <Flex>
-                <>
-                  <Text textStyle="subHeading" marginRight="12px">
-                    Session {key+1}
-                  </Text>
-                  {
-                    (() => {
-                        if (getCampStatus(camp) === "Published"){
-                          return session.campers.length >= session.capacity ? (
-                            <Tag colorScheme="orange" borderRadius="full" size="sm">
-                              Session full
-                            </Tag>
-                          ) : (
-                            <Tag colorScheme="green" borderRadius="full" size="sm">
-                              Session available
-                            </Tag>
-                          )
-                        }
-                        return ""
-                    })()
-                  }
-                </>
-              </Flex>
-              <Text textStyle="subHeading">
-                {getFormattedDateString(session.dates)}
-              </Text> 
-              <Text textStyle="caption">
-                Registrations (
-                  <Text
-                    as="span"
-                    textStyle={getCampStatus(camp) === "Published" && session.campers.length >= session.capacity?"subHeading":"caption"}
-                  >
-                    {session.campers.length}/{session.capacity}
-                  </Text>
-                ) | Waitlist ({session.waitlist.length})
-              </Text>
-            </Box>
+              <PreviewModalSessionRow key={key} sessionNum={key+1} status={getCampStatus(camp)} session={session}/>
           )
           })}
 

--- a/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Box, Flex, Text, Tag } from '@chakra-ui/react'
+import { getFormattedDateString } from '../../../utils/CampUtils'
+import { CampSession } from '../../../types/CampsTypes';
+
+
+type PreviewModalSessionRowProps = {
+    sessionNum: number;
+    status: string
+    session: CampSession
+  }
+
+const PreviewModalSessionRow = ({sessionNum, status, session}: PreviewModalSessionRowProps): JSX.Element => {
+    return (
+        <Box
+            marginBottom="12px"
+        >
+            <Flex>
+                <>
+                    <Text textStyle="subHeading" marginRight="12px">
+                        Session {sessionNum}
+                    </Text>
+                    {
+                    (() => {
+                        if (status === "Published"){
+                            return session.campers.length >= session.capacity ? (
+                            <Tag colorScheme="orange" borderRadius="full" size="sm">
+                                Session full
+                            </Tag>
+                            ) : (
+                            <Tag colorScheme="green" borderRadius="full" size="sm">
+                                Session available
+                            </Tag>
+                            )
+                        }
+                        return ""
+                    })()
+                    }
+                </>
+            </Flex>
+        <Text textStyle="subHeading">
+            {getFormattedDateString(session.dates)}
+        </Text> 
+        <Text textStyle="caption">
+            Registrations (
+                <Text
+                as="span"
+                textStyle={status === "Published" && session.campers.length >= session.capacity?"subHeading":"caption"}
+                >
+                {session.campers.length}/{session.capacity}
+                </Text>
+            ) | Waitlist ({session.waitlist.length})
+        </Text>
+    </Box>
+  )
+}
+
+export default PreviewModalSessionRow

--- a/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
@@ -1,58 +1,61 @@
-import React from 'react'
-import { Box, Flex, Text, Tag } from '@chakra-ui/react'
-import { getFormattedDateString } from '../../../utils/CampUtils'
-import { CampSession } from '../../../types/CampsTypes';
-
+import React from "react";
+import { Box, Flex, Text, Tag } from "@chakra-ui/react";
+import { getFormattedDateString } from "../../../utils/CampUtils";
+import { CampSession } from "../../../types/CampsTypes";
 
 type PreviewModalSessionRowProps = {
-    sessionNum: number;
-    status: string
-    session: CampSession
-  }
+  sessionNum: number;
+  status: string;
+  session: CampSession;
+};
 
-const PreviewModalSessionRow = ({sessionNum, status, session}: PreviewModalSessionRowProps): JSX.Element => {
-    return (
-        <Box
-            marginBottom="12px"
+const PreviewModalSessionRow = ({
+  sessionNum,
+  status,
+  session,
+}: PreviewModalSessionRowProps): JSX.Element => {
+  return (
+    <Box marginBottom="12px">
+      <Flex>
+        <>
+          <Text textStyle="subHeading" marginRight="12px">
+            Session {sessionNum}
+          </Text>
+          {(() => {
+            if (status === "Published") {
+              return session.campers.length >= session.capacity ? (
+                <Tag colorScheme="orange" borderRadius="full" size="sm">
+                  Session full
+                </Tag>
+              ) : (
+                <Tag colorScheme="green" borderRadius="full" size="sm">
+                  Session available
+                </Tag>
+              );
+            }
+            return "";
+          })()}
+        </>
+      </Flex>
+      <Text textStyle="subHeading">
+        {getFormattedDateString(session.dates)}
+      </Text>
+      <Text textStyle="caption">
+        Registrations (
+        <Text
+          as="span"
+          textStyle={
+            status === "Published" && session.campers.length >= session.capacity
+              ? "subHeading"
+              : "caption"
+          }
         >
-            <Flex>
-                <>
-                    <Text textStyle="subHeading" marginRight="12px">
-                        Session {sessionNum}
-                    </Text>
-                    {
-                    (() => {
-                        if (status === "Published"){
-                            return session.campers.length >= session.capacity ? (
-                            <Tag colorScheme="orange" borderRadius="full" size="sm">
-                                Session full
-                            </Tag>
-                            ) : (
-                            <Tag colorScheme="green" borderRadius="full" size="sm">
-                                Session available
-                            </Tag>
-                            )
-                        }
-                        return ""
-                    })()
-                    }
-                </>
-            </Flex>
-        <Text textStyle="subHeading">
-            {getFormattedDateString(session.dates)}
-        </Text> 
-        <Text textStyle="caption">
-            Registrations (
-                <Text
-                as="span"
-                textStyle={status === "Published" && session.campers.length >= session.capacity?"subHeading":"caption"}
-                >
-                {session.campers.length}/{session.capacity}
-                </Text>
-            ) | Waitlist ({session.waitlist.length})
+          {session.campers.length}/{session.capacity}
         </Text>
+        ) | Waitlist ({session.waitlist.length})
+      </Text>
     </Box>
-  )
-}
+  );
+};
 
-export default PreviewModalSessionRow
+export default PreviewModalSessionRow;

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -1,26 +1,37 @@
-import { Container } from "@chakra-ui/react";
+import { Flex, Box, useDisclosure } from "@chakra-ui/react";
 import React, { useState } from "react";
+import { CampResponse } from "../../../types/CampsTypes";
 import CampsNavigationHeading from "./CampsNavigationHeading";
 import CampsTable from "./CampsTable";
+import PreviewCampDrawer from "./PreviewCampDrawer";
 
 const CampsListPage = (): React.ReactElement => {
   const [year, setYear] = useState(new Date().getFullYear());
+  const {isOpen:isDrawerOpen, onOpen:onDrawerOpen, onClose:onDrawerClose} = useDisclosure()
+  const [campDrawerInfo, setCampDrawerInfo] = useState<CampResponse>()
 
   return (
-    <Container
-      maxWidth="100vw"
-      minHeight="100vh"
-      px="3em"
-      py="3em"
-      background="background.grey.200"
+    <Flex 
+      width={isDrawerOpen?"calc(100% - 500px)":"100%"}
+      transition="width 0.5s"
+      top = "68px"
     >
-      <CampsNavigationHeading
-        year={year}
-        onNavigateLeft={() => setYear(year - 1)}
-        onNavigateRight={() => setYear(year + 1)}
-      />
-      <CampsTable year={year} />
-    </Container>
+      <Box
+        minHeight="100vh"
+        px="3em"
+        py="3em"
+        background="background.grey.200"
+        flex="1"
+      >
+        <CampsNavigationHeading
+          year={year}
+          onNavigateLeft={() => {setYear(year - 1); onDrawerClose()}}
+          onNavigateRight={() => {setYear(year + 1); onDrawerClose()}}
+        />
+        <CampsTable year={year} onDrawerOpen={onDrawerOpen} setCampDrawerInfo={setCampDrawerInfo}/>
+      </Box>
+      <PreviewCampDrawer isOpen={isDrawerOpen} onClose={onDrawerClose} camp={campDrawerInfo}/>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -28,7 +28,13 @@ const CampsListPage = (): React.ReactElement => {
           onNavigateLeft={() => {setYear(year - 1); onDrawerClose()}}
           onNavigateRight={() => {setYear(year + 1); onDrawerClose()}}
         />
-        <CampsTable year={year} onDrawerOpen={onDrawerOpen} setCampDrawerInfo={setCampDrawerInfo}/>
+        <CampsTable 
+          year={year}
+          isDrawerOpen={isDrawerOpen} 
+          onDrawerOpen={onDrawerOpen}
+          campDrawerInfo={campDrawerInfo}
+          setCampDrawerInfo={setCampDrawerInfo}
+        />
       </Box>
       <PreviewCampDrawer isOpen={isDrawerOpen} onClose={onDrawerClose} camp={campDrawerInfo}/>
     </Flex>

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -7,14 +7,18 @@ import PreviewCampDrawer from "./PreviewCampDrawer";
 
 const CampsListPage = (): React.ReactElement => {
   const [year, setYear] = useState(new Date().getFullYear());
-  const {isOpen:isDrawerOpen, onOpen:onDrawerOpen, onClose:onDrawerClose} = useDisclosure()
-  const [campDrawerInfo, setCampDrawerInfo] = useState<CampResponse>()
+  const {
+    isOpen: isDrawerOpen,
+    onOpen: onDrawerOpen,
+    onClose: onDrawerClose,
+  } = useDisclosure();
+  const [campDrawerInfo, setCampDrawerInfo] = useState<CampResponse>();
 
   return (
-    <Flex 
-      width={isDrawerOpen?"calc(100% - 500px)":"100%"}
+    <Flex
+      width={isDrawerOpen ? "calc(100% - 500px)" : "100%"}
       transition="width 0.5s"
-      top = "68px"
+      top="68px"
     >
       <Box
         minHeight="100vh"
@@ -25,8 +29,14 @@ const CampsListPage = (): React.ReactElement => {
       >
         <CampsNavigationHeading
           year={year}
-          onNavigateLeft={() => {setYear(year - 1); onDrawerClose()}}
-          onNavigateRight={() => {setYear(year + 1); onDrawerClose()}}
+          onNavigateLeft={() => {
+            setYear(year - 1);
+            onDrawerClose();
+          }}
+          onNavigateRight={() => {
+            setYear(year + 1);
+            onDrawerClose();
+          }}
         />
         <CampsTable 
           year={year}
@@ -36,7 +46,11 @@ const CampsListPage = (): React.ReactElement => {
           setCampDrawerInfo={setCampDrawerInfo}
         />
       </Box>
-      <PreviewCampDrawer isOpen={isDrawerOpen} onClose={onDrawerClose} camp={campDrawerInfo}/>
+      <PreviewCampDrawer
+        isOpen={isDrawerOpen}
+        onClose={onDrawerClose}
+        camp={campDrawerInfo}
+      />
     </Flex>
   );
 };

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -38,9 +38,9 @@ const CampsListPage = (): React.ReactElement => {
             onDrawerClose();
           }}
         />
-        <CampsTable 
+        <CampsTable
           year={year}
-          isDrawerOpen={isDrawerOpen} 
+          isDrawerOpen={isDrawerOpen}
           onDrawerOpen={onDrawerOpen}
           campDrawerInfo={campDrawerInfo}
           setCampDrawerInfo={setCampDrawerInfo}

--- a/frontend/src/utils/CSVUtils.ts
+++ b/frontend/src/utils/CSVUtils.ts
@@ -88,7 +88,12 @@ export const downloadCSV = (data: string, fileName: string): void => {
  * @param campSessionDate camp session start date (e.g. "Thu Jun 30 2022 00:00:00 GMT+0000 (Coordinated Universal Time)")
  * @return name of the CSV file (e.g. "Waterloo_Jun_3_2022")
  */
-export const generateCSVName = (campCity: string, campSessionDate: string): string => {
+export const generateCSVName = (
+  campCity: string,
+  campSessionDate: string,
+): string => {
   const startDate = new Date(campSessionDate);
-  return `${campCity}_${startDate.toLocaleString('default', { month: 'short' })}_${startDate.getDay()}_${startDate.getFullYear()}`;
+  return `${campCity}_${startDate.toLocaleString("default", {
+    month: "short",
+  })}_${startDate.getDay()}_${startDate.getFullYear()}`;
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp List: Camp Preview](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=ec49d3c3237d4080adecdc321f7df86c&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
 - Implemented camp preview drawer as per designs and ticket
 
Design justification:
 - Only clicking the name/address area of a table's row activates the drawer. If the whole row is clickable, clicking the triple dot button activates both the drawer and delete camp tooltip popup at the same time
 - Changing the year closes the drawer as some years don't have camps
 - Drawer is fixed right now, on the assumption that the navbar will be made sticky


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click on camps to open the drawer
2. Close the drawer
3. Scroll and see if the drawer stays fixed (there will be a gap at the top as the navbar is not sticky in my branch but from Slack discussion, the navbar will be made sticky eventually)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* PreviewCampDrawer.tsx


## Checklist
- [ yuh ] My PR name is descriptive and in imperative tense
- [ kinda ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ yer ] I have run the appropriate linter(s)
- [ yuh ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
