### PR TITLE
fix: Auto log-out user instead of refreshing when token expires

### DIFF
--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -1,9 +1,7 @@
 import axios, { AxiosRequestConfig } from "axios";
 import jwt from "jsonwebtoken";
 
-import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { DecodedJWT } from "../types/AuthTypes";
-import { setLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 
 const baseAPIClient = axios.create({
   baseURL: process.env.REACT_APP_BACKEND_URL,
@@ -12,7 +10,7 @@ const baseAPIClient = axios.create({
 baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
   const newConfig = { ...config };
 
-  // if access token in header has expired, do a refresh
+  // if access token in header has expired, auto-logout the user
   const authHeaderParts = config.headers.Authorization?.split(" ");
   if (
     authHeaderParts &&
@@ -26,20 +24,8 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
       (typeof decodedToken === "string" ||
         decodedToken.exp <= Math.round(new Date().getTime() / 1000))
     ) {
-      const { data } = await axios.post(
-        `${process.env.REACT_APP_BACKEND_URL}/auth/refresh`,
-        {},
-        { withCredentials: true },
-      );
-
-      const accessToken = data.accessToken || data.access_token;
-      setLocalStorageObjProperty(
-        AUTHENTICATED_USER_KEY,
-        "accessToken",
-        accessToken,
-      );
-
-      newConfig.headers.Authorization = `Bearer ${accessToken}`;
+      localStorage.clear();
+      window.location.reload();
     }
   }
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Login Auth not working after token expires](https://www.notion.so/uwblueprintexecs/Login-Auth-refresh-not-working-after-token-expires-7e98633addd04560a6ffeb028d3a0fdc)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Auto log out user instead of doing the refresh (see the Community Fridge fix for the same issue: https://github.com/uwblueprint/community-fridge-kw/pull/193)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in
2. After 1 hour, you should automatically be logged out


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
