### PR TITLE
fix: Replace BEARER_TOKEN constant to be a function

### DIFF
--- a/frontend/src/APIClients/AdminAPIClient.ts
+++ b/frontend/src/APIClients/AdminAPIClient.ts
@@ -1,4 +1,4 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
+import { getBearerToken } from "../constants/AuthConstants";
 import baseAPIClient from "./BaseAPIClient";
 import { FormTemplate, UpdateWaiverRequest, Waiver } from "../types/AdminTypes";
 import { CreateFormQuestion, FormQuestion } from "../types/CampsTypes";
@@ -11,7 +11,7 @@ const updateWaiver = async (
       `/admin/waiver`,
       updateWaiverData,
       {
-        headers: { Authorization: BEARER_TOKEN },
+        headers: { Authorization: getBearerToken() },
       },
     );
     return data;
@@ -23,7 +23,7 @@ const updateWaiver = async (
 const getWaiver = async (): Promise<Waiver> => {
   try {
     const { data } = await baseAPIClient.get(`/admin/waiver`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {
@@ -39,7 +39,7 @@ const addQuestionToTemplate = async (
       `/admin/formTemplate/formQuestion`,
       { formQuestion: newFormQuestion },
       {
-        headers: { Authorization: BEARER_TOKEN },
+        headers: { Authorization: getBearerToken() },
       },
     );
     return data;
@@ -51,7 +51,7 @@ const addQuestionToTemplate = async (
 const getFormTemplate = async (): Promise<FormTemplate> => {
   try {
     const { data } = await baseAPIClient.get("/admin/formTemplate", {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -1,4 +1,4 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
+import { getBearerToken } from "../constants/AuthConstants";
 import {
   WaitlistedCamper,
   UpdateWaitlistedStatusType,
@@ -27,7 +27,7 @@ const updateCampersById = async (
     }
 
     const { data } = await baseAPIClient.patch(`/campers`, body, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
 
     return data;
@@ -41,7 +41,7 @@ const getWaitlistedCamperById = async (
 ): Promise<WaitlistedCamper> => {
   try {
     const { data } = await baseAPIClient.get(`/campers/waitlist/${id}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {
@@ -58,7 +58,7 @@ const updateCamperRegistrationStatus = async (
       `/campers/waitlist/${id}`,
       updatedStatus,
       {
-        headers: { Authorization: BEARER_TOKEN },
+        headers: { Authorization: getBearerToken() },
       },
     );
     return data;
@@ -70,7 +70,7 @@ const updateCamperRegistrationStatus = async (
 const deleteWaitlistedCamperById = async (id: string): Promise<boolean> => {
   try {
     await baseAPIClient.delete(`/campers/waitlist/${id}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return true;
   } catch (error) {
@@ -81,7 +81,7 @@ const deleteWaitlistedCamperById = async (id: string): Promise<boolean> => {
 const deleteMultipleCampersById = async (ids: string[]): Promise<boolean> => {
   try {
     await baseAPIClient.delete(`/campers/`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
       data: {
         camperIds: ids,
       },
@@ -100,7 +100,7 @@ const getCampersByChargeIdAndSessionId = async (
     const { data } = await baseAPIClient.get(
       `/campers/${chargeId}/${sessionId}`,
       {
-        headers: { Authorization: BEARER_TOKEN },
+        headers: { Authorization: getBearerToken() },
       },
     );
     return data;

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -1,4 +1,4 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
+import { getBearerToken } from "../constants/AuthConstants";
 import {
   CampResponse,
   CampSessionResponse,
@@ -11,7 +11,7 @@ const getAllCamps = async (year?: number): Promise<Array<CampResponse>> => {
     const { data } = await baseAPIClient.get(
       `/camp?campYear=${year?.toString()}`,
       {
-        headers: { Authorization: BEARER_TOKEN },
+        headers: { Authorization: getBearerToken() },
       },
     );
     return data;
@@ -23,7 +23,7 @@ const getAllCamps = async (year?: number): Promise<Array<CampResponse>> => {
 const getCampById = async (id: string): Promise<CampResponse> => {
   try {
     const { data } = await baseAPIClient.get(`/camp/${id}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {
@@ -45,7 +45,7 @@ const editCampById = async (
     formData.append("data", JSON.stringify(fieldsToUpdate));
     const { data } = await baseAPIClient.patch(`/camp/${id}`, formData, {
       headers: {
-        Authorization: BEARER_TOKEN,
+        Authorization: getBearerToken(),
       },
     });
     return data;
@@ -57,7 +57,7 @@ const editCampById = async (
 const deleteCamp = async (id: string): Promise<boolean> => {
   try {
     await baseAPIClient.delete(`/camp/${id}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return true;
   } catch (error) {
@@ -72,7 +72,7 @@ const updateCampSessions = async (
   try {
     const { data } = await baseAPIClient.patch(`/camp/${campId}/session`, {
       headers: {
-        Authorization: BEARER_TOKEN,
+        Authorization: getBearerToken(),
       },
       data: {
         updatedCampSessions,
@@ -92,7 +92,7 @@ const deleteCampSessionsByIds = async (
   try {
     await baseAPIClient.delete(`/camp/${campId}/session`, {
       headers: {
-        Authorization: BEARER_TOKEN,
+        Authorization: getBearerToken(),
       },
       data: {
         campSessionIds,
@@ -107,7 +107,7 @@ const deleteCampSessionsByIds = async (
 const getCampSessionCsv = async (id: string): Promise<string> => {
   try {
     const { data } = await baseAPIClient.get(`/camp/csv/${id}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {

--- a/frontend/src/APIClients/UserAPIClient.ts
+++ b/frontend/src/APIClients/UserAPIClient.ts
@@ -1,11 +1,11 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
+import { getBearerToken } from "../constants/AuthConstants";
 import baseAPIClient from "./BaseAPIClient";
 import { UserRequest, UserResponse } from "../types/UserTypes";
 
 const getAllUsers = async (): Promise<Array<UserResponse>> => {
   try {
     const { data } = await baseAPIClient.get(`/users`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {
@@ -19,7 +19,7 @@ const updateUserById = async (
 ): Promise<boolean> => {
   try {
     await baseAPIClient.put(`/users/${id}`, userData, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return true;
   } catch (error) {

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -31,10 +31,7 @@ const CampCreationPage = (): React.ReactElement => {
 
   // All state for registration form page.
 
-  const [
-    formTemplate,
-    setFormTemplate,
-  ] = useState<FormTemplate>();
+  const [formTemplate, setFormTemplate] = useState<FormTemplate>();
 
   useEffect(() => {
     const getFormTemplate = async () => {

--- a/frontend/src/constants/AuthConstants.ts
+++ b/frontend/src/constants/AuthConstants.ts
@@ -2,12 +2,11 @@ import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 
 const AUTHENTICATED_USER_KEY = `${window.location.hostname}:AUTHENTICATED_USER`;
 
-export const getBearerToken = () => 
-{ 
+export const getBearerToken = (): string => {
   return `Bearer ${getLocalStorageObjProperty(
-  AUTHENTICATED_USER_KEY,
-  "accessToken",
-)}`; 
-}
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+};
 
 export default AUTHENTICATED_USER_KEY;

--- a/frontend/src/constants/AuthConstants.ts
+++ b/frontend/src/constants/AuthConstants.ts
@@ -2,9 +2,12 @@ import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 
 const AUTHENTICATED_USER_KEY = `${window.location.hostname}:AUTHENTICATED_USER`;
 
-export const BEARER_TOKEN = `Bearer ${getLocalStorageObjProperty(
+export const getBearerToken = () => 
+{ 
+  return `Bearer ${getLocalStorageObjProperty(
   AUTHENTICATED_USER_KEY,
   "accessToken",
-)}`;
+)}`; 
+}
 
 export default AUTHENTICATED_USER_KEY;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Access management table not loading on first visit](https://www.notion.so/uwblueprintexecs/Access-Management-Table-not-loading-on-first-visit-0ccaa7ab18504bb787071999442079c9)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The access management table was not loading on first load because the BEARER_TOKEN was `null` for some reason, we found that changing the `BEARER_TOKEN` constant to be a function fixed the issue, probably bc when the `BEARER_TOKEN` first gets its value upon page load, it doesn't update unless we refresh the page, but we want to get the access token value at the given moment


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login
2. Go to access management page for the first time upon logging in
3. Data in the table should load without refreshing


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
