### PR TITLE
removes the Camp Specific option from form template add question modal

### DIFF
--- a/frontend/src/components/common/formQuestions/AddQuestionModal/index.tsx
+++ b/frontend/src/components/common/formQuestions/AddQuestionModal/index.tsx
@@ -35,7 +35,7 @@ type AddQuestionModalProps = {
   ) => void;
   questionToBeEdited?: CreateFormQuestion;
   editing?: boolean;
-  isTemplatePage?: boolean;
+  isFormTemplatePage?: boolean;
 };
 
 const AddQuestionModal = ({
@@ -45,7 +45,7 @@ const AddQuestionModal = ({
   onEdit,
   questionToBeEdited,
   editing = false,
-  isTemplatePage = false,
+  isFormTemplatePage = false,
 }: AddQuestionModalProps): React.ReactElement => {
   const [question, setQuestion] = useState<string>("");
   const [questionCategory, setQuestionCategory] = useState<string>(
@@ -151,7 +151,7 @@ const AddQuestionModal = ({
               >
                 <option value="PersonalInfo">Camper Information</option>
                 <option value="EmergencyContact">Emergency Contact</option>
-                {!isTemplatePage && (
+                {!isFormTemplatePage && (
                   <option value="CampSpecific">
                     Camp Specific Information
                   </option>

--- a/frontend/src/components/common/formQuestions/AddQuestionModal/index.tsx
+++ b/frontend/src/components/common/formQuestions/AddQuestionModal/index.tsx
@@ -35,6 +35,7 @@ type AddQuestionModalProps = {
   ) => void;
   questionToBeEdited?: CreateFormQuestion;
   editing?: boolean;
+  isTemplatePage?: boolean;
 };
 
 const AddQuestionModal = ({
@@ -44,6 +45,7 @@ const AddQuestionModal = ({
   onEdit,
   questionToBeEdited,
   editing = false,
+  isTemplatePage = false,
 }: AddQuestionModalProps): React.ReactElement => {
   const [question, setQuestion] = useState<string>("");
   const [questionCategory, setQuestionCategory] = useState<string>(
@@ -149,7 +151,11 @@ const AddQuestionModal = ({
               >
                 <option value="PersonalInfo">Camper Information</option>
                 <option value="EmergencyContact">Emergency Contact</option>
-                <option value="CampSpecific">Camp Specific Information</option>
+                {!isTemplatePage && (
+                  <option value="CampSpecific">
+                    Camp Specific Information
+                  </option>
+                )}
               </Select>
             </FormControl>
 

--- a/frontend/src/components/pages/GlobalForms/Footer/Footer.tsx
+++ b/frontend/src/components/pages/GlobalForms/Footer/Footer.tsx
@@ -53,7 +53,7 @@ const Footer = ({
         isOpen={isAddQuestionOpen && !isWaiverFooter}
         onClose={onAddQuestionClose}
         onSave={onAddFormQuestionToTemplateClick}
-        isTemplatePage
+        isFormTemplatePage
       />
       <Flex
         pos="fixed"

--- a/frontend/src/components/pages/GlobalForms/Footer/Footer.tsx
+++ b/frontend/src/components/pages/GlobalForms/Footer/Footer.tsx
@@ -53,6 +53,7 @@ const Footer = ({
         isOpen={isAddQuestionOpen && !isWaiverFooter}
         onClose={onAddQuestionClose}
         onSave={onAddFormQuestionToTemplateClick}
+        isTemplatePage
       />
       <Flex
         pos="fixed"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Global Forms: Remove the “Camp Specific” option if the admin is trying to add a question to the global forms](https://www.notion.so/uwblueprintexecs/8902e20b0cae4db2b4776259238f8a4e?v=4cf916ddabfc4438a2685c0990a4fc57&p=5067a23b7d1e4fc4b58d7f10cf195484&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. try to add a question on camp creation flow and to the form template


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
