### PR TITLE
fix: heroku only considers pushes from main branch

### DIFF
--- a/.github/workflows/heroku-deploy-dev-ts.yml
+++ b/.github/workflows/heroku-deploy-dev-ts.yml
@@ -51,4 +51,4 @@ jobs:
         env:
           HEROKU_APP_NAME: "${{ secrets.HEROKU_APP_NAME }}"
       - name: Push to Heroku
-        run: git subtree push --prefix backend/typescript heroku dev
+        run: git subtree push --prefix backend/typescript heroku dev:main


### PR DESCRIPTION

<img width="1094" alt="Screen Shot 2022-12-06 at 6 29 17 AM" src="https://user-images.githubusercontent.com/40974372/205900025-a8706dc1-b69c-4ad0-8183-bcb21b1ba8b8.png">

https://devcenter.heroku.com/articles/git#deploy-from-a-branch-besides-main

https://help.heroku.com/CKVOUPSY/how-to-switch-deployment-method-from-github-to-heroku-git-with-all-the-changes-app-code-available-in-a-github-repo

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
