### PR TITLE
Feat: Populates initial data for Camp Edit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,11 @@ const App = (): React.ReactElement => {
               path={Routes.CAMP_CREATION_PAGE}
               component={CampCreationPage}
             />
+            <PrivateRoute
+              exact
+              path={Routes.CAMP_EDIT_PAGE}
+              component={CampCreationPage}
+            />
             <Route
               exact
               path={Routes.CAMP_REGISTER_PAGE}

--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -13,6 +13,7 @@ import {
   Image,
 } from "@chakra-ui/react";
 import IconImage from "../../../../assets/icon_image.svg";
+import { MAX_CAMP_DESC_LENGTH } from "../../../../constants/CampManagementConstants";
 
 type CampCreationDetailsProps = {
   campName: string;
@@ -174,7 +175,7 @@ const CampCreationDetails = ({
       {errorText(campName, "You must add a name.")}
 
       <Text textStyle="buttonSemiBold" marginTop="24px">
-        Short Description (max 400 characters){" "}
+        Short Description (max ${MAX_CAMP_DESC_LENGTH.toString()} characters){" "}
         <Text as="span" textStyle="buttonSemiBold" color="red">
           *
         </Text>
@@ -182,7 +183,7 @@ const CampCreationDetails = ({
       <Textarea
         width="575px"
         marginTop="8px"
-        maxLength={400}
+        maxLength={MAX_CAMP_DESC_LENGTH}
         defaultValue={campDescription}
         borderColor={!campDescription && showErrors ? "red" : "gray.200"}
         borderWidth={!campDescription && showErrors ? "2px" : "1px"}
@@ -204,7 +205,6 @@ const CampCreationDetails = ({
           type="number"
           placeholder="0.00"
           defaultValue={dailyCampFee}
-          key={dailyCampFee ? "loaded-camp-fee" : "loading-camp-fee"}
           borderColor={!dailyCampFee && showErrors ? "red" : "gray.200"}
           borderWidth={!dailyCampFee && showErrors ? "2px" : "1px"}
           onChange={handleDailyCampFee}
@@ -281,7 +281,6 @@ const CampCreationDetails = ({
                 height="52px"
                 maxLength={2}
                 defaultValue={ageLower}
-                key={ageLower ? "loaded-age-lower" : "loading-age-lower"}
                 borderColor={!ageLower && showErrors ? "red" : "gray.200"}
                 borderWidth={!ageLower && showErrors ? "2px" : "1px"}
                 onChange={handleAgeLower}
@@ -296,7 +295,6 @@ const CampCreationDetails = ({
                 height="52px"
                 maxLength={2}
                 defaultValue={ageUpper}
-                key={ageUpper ? "loaded-age-upper" : "loading-age-upper"}
                 borderColor={!ageUpper && showErrors ? "red" : "gray.200"}
                 borderWidth={!ageUpper && showErrors ? "2px" : "1px"}
                 onChange={handleAgeUpper}
@@ -320,9 +318,6 @@ const CampCreationDetails = ({
               height="52px"
               marginTop="8px"
               defaultValue={campCapacity}
-              key={
-                campCapacity ? "loaded-camp-capacity" : "loading-camp-capacity"
-              }
               borderColor={!campCapacity && showErrors ? "red" : "gray.200"}
               borderWidth={!campCapacity && showErrors ? "2px" : "1px"}
               onChange={handleCampCapacity}
@@ -411,7 +406,6 @@ const CampCreationDetails = ({
               type="number"
               placeholder="0.00"
               defaultValue={priceEDLP}
-              key={priceEDLP ? "loaded-priceEDLP" : "loading-priceEDLP"}
               borderColor={!priceEDLP && showErrors ? "red" : "gray.200"}
               borderWidth={!priceEDLP && showErrors ? "2px" : "1px"}
               onChange={handlePriceEDLP}
@@ -470,7 +464,6 @@ const CampCreationDetails = ({
             height="52px"
             marginTop="8px"
             defaultValue={city}
-            key={city ? "loaded-city" : "loading-city"}
             borderColor={!city && showErrors ? "red" : "gray.200"}
             borderWidth={!city && showErrors ? "2px" : "1px"}
             onChange={handleCity}
@@ -488,7 +481,6 @@ const CampCreationDetails = ({
             height="52px"
             marginTop="8px"
             defaultValue={province}
-            key={province === "-" ? "loading-province" : "loaded-province"}
             borderColor={
               (!province || province === "-") && showErrors ? "red" : "gray.200"
             }
@@ -531,7 +523,6 @@ const CampCreationDetails = ({
             marginTop="8px"
             maxLength={7}
             defaultValue={postalCode}
-            key={postalCode ? "loaded-postalCode" : "loading-postalCode"}
             borderColor={!postalCode && showErrors ? "red" : "gray.200"}
             borderWidth={!postalCode && showErrors ? "2px" : "1px"}
             onChange={handlePostalCode}

--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -174,7 +174,7 @@ const CampCreationDetails = ({
       {errorText(campName, "You must add a name.")}
 
       <Text textStyle="buttonSemiBold" marginTop="24px">
-        Short Description (max 200 characters){" "}
+        Short Description (max 400 characters){" "}
         <Text as="span" textStyle="buttonSemiBold" color="red">
           *
         </Text>
@@ -182,7 +182,7 @@ const CampCreationDetails = ({
       <Textarea
         width="575px"
         marginTop="8px"
-        maxLength={200}
+        maxLength={400}
         defaultValue={campDescription}
         borderColor={!campDescription && showErrors ? "red" : "gray.200"}
         borderWidth={!campDescription && showErrors ? "2px" : "1px"}
@@ -204,6 +204,7 @@ const CampCreationDetails = ({
           type="number"
           placeholder="0.00"
           defaultValue={dailyCampFee}
+          key={dailyCampFee ? "loaded-camp-fee" : "loading-camp-fee"}
           borderColor={!dailyCampFee && showErrors ? "red" : "gray.200"}
           borderWidth={!dailyCampFee && showErrors ? "2px" : "1px"}
           onChange={handleDailyCampFee}
@@ -280,6 +281,7 @@ const CampCreationDetails = ({
                 height="52px"
                 maxLength={2}
                 defaultValue={ageLower}
+                key={ageLower ? "loaded-age-lower" : "loading-age-lower"}
                 borderColor={!ageLower && showErrors ? "red" : "gray.200"}
                 borderWidth={!ageLower && showErrors ? "2px" : "1px"}
                 onChange={handleAgeLower}
@@ -294,6 +296,7 @@ const CampCreationDetails = ({
                 height="52px"
                 maxLength={2}
                 defaultValue={ageUpper}
+                key={ageUpper ? "loaded-age-upper" : "loading-age-upper"}
                 borderColor={!ageUpper && showErrors ? "red" : "gray.200"}
                 borderWidth={!ageUpper && showErrors ? "2px" : "1px"}
                 onChange={handleAgeUpper}
@@ -317,6 +320,9 @@ const CampCreationDetails = ({
               height="52px"
               marginTop="8px"
               defaultValue={campCapacity}
+              key={
+                campCapacity ? "loaded-camp-capacity" : "loading-camp-capacity"
+              }
               borderColor={!campCapacity && showErrors ? "red" : "gray.200"}
               borderWidth={!campCapacity && showErrors ? "2px" : "1px"}
               onChange={handleCampCapacity}
@@ -326,7 +332,7 @@ const CampCreationDetails = ({
         </Box>
       </HStack>
 
-      <Checkbox marginTop="8px" onChange={toggleEDLP}>
+      <Checkbox marginTop="8px" onChange={toggleEDLP} isChecked={offersEDLP}>
         <Text textStyle="buttonSemiBold">
           Camp offers early drop-off and late pick-up
         </Text>
@@ -405,6 +411,7 @@ const CampCreationDetails = ({
               type="number"
               placeholder="0.00"
               defaultValue={priceEDLP}
+              key={priceEDLP ? "loaded-priceEDLP" : "loading-priceEDLP"}
               borderColor={!priceEDLP && showErrors ? "red" : "gray.200"}
               borderWidth={!priceEDLP && showErrors ? "2px" : "1px"}
               onChange={handlePriceEDLP}
@@ -463,6 +470,7 @@ const CampCreationDetails = ({
             height="52px"
             marginTop="8px"
             defaultValue={city}
+            key={city ? "loaded-city" : "loading-city"}
             borderColor={!city && showErrors ? "red" : "gray.200"}
             borderWidth={!city && showErrors ? "2px" : "1px"}
             onChange={handleCity}
@@ -480,6 +488,7 @@ const CampCreationDetails = ({
             height="52px"
             marginTop="8px"
             defaultValue={province}
+            key={province === "-" ? "loading-province" : "loaded-province"}
             borderColor={
               (!province || province === "-") && showErrors ? "red" : "gray.200"
             }
@@ -522,6 +531,7 @@ const CampCreationDetails = ({
             marginTop="8px"
             maxLength={7}
             defaultValue={postalCode}
+            key={postalCode ? "loaded-postalCode" : "loading-postalCode"}
             borderColor={!postalCode && showErrors ? "red" : "gray.200"}
             borderWidth={!postalCode && showErrors ? "2px" : "1px"}
             onChange={handlePostalCode}

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -19,7 +19,6 @@ import CampCreationDetails from "./CampDetails";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
 import { getSelectedWeekDaysFromDates } from "../../../utils/CampUtils";
 
-
 const CampCreationPage = (): React.ReactElement => {
   // All response state from the three page components.
   const [campName, setCampName] = useState<string>("");
@@ -212,6 +211,34 @@ const CampCreationPage = (): React.ReactElement => {
           },
         );
         setCustomQuestions(currentFormQuestions);
+
+        // Set basic camp details
+        setCampName(editCamp.name);
+        setCampDescription(editCamp.description);
+        setDailyCampFee(editCamp.fee);
+        setStartTime(editCamp.startTime);
+        setEndTime(editCamp.endTime);
+        setAgeLower(editCamp.ageLower);
+        setAgeUpper(editCamp.ageUpper);
+        setOffersEDLP(
+          editCamp.earlyDropoff.length !== 0 ||
+            editCamp.latePickup.length !== 0,
+        );
+        setEarliestDropOffTime(editCamp.earlyDropoff);
+        setLatestPickUpTime(editCamp.latePickup);
+        setPriceEDLP(editCamp.pickupFee);
+        setAddresLine1(editCamp.location.streetAddress1);
+        setAddresLine2(editCamp.location.streetAddress2 ?? "");
+        setCity(editCamp.location.city);
+        setProvince(editCamp.location.province);
+        setPostalCode(editCamp.location.postalCode);
+        setCampImageURL(editCamp.campPhotoUrl);
+
+        // Set camp level capacity from camp sessions
+        if (editCamp.campSessions.length > 0) {
+          // At the creation stage, all the sessions should have the same capacity
+          setCampCapacity(editCamp.campSessions[0].capacity);
+        }
       }
     };
 

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -13,7 +13,6 @@ import AdminAPIClient from "../../../APIClients/AdminAPIClient";
 import {
   CreateFormQuestion,
   CreateCampSession,
-  CampResponse,
 } from "../../../types/CampsTypes";
 import CampCreationDetails from "./CampDetails";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
@@ -167,7 +166,6 @@ const CampCreationPage = (): React.ReactElement => {
 
   // The edit-camp route will have an id to identify the camp currently in draft state
   const { id: editCampId } = useParams<{ id: string }>();
-  const [campToEdit, setCampToEdit] = useState<CampResponse>();
 
   // This useEffect fetches the current state of the draft camp if we are editing camp
   useEffect(() => {
@@ -176,8 +174,6 @@ const CampCreationPage = (): React.ReactElement => {
       const editCamp = await CampsAPIClient.getCampById(editCampId);
 
       if (editCamp) {
-        setCampToEdit(editCamp); // Store the current state of the camp to edit
-
         // Schedule Sessions need the data in a certain format. We convert the array of dates stored in the backend
         // to this array of CreateCampSessions so that the sessions can be viewed/edited/deleted
         const currentCampSessions: CreateCampSession[] = editCamp.campSessions.map(
@@ -252,87 +248,85 @@ const CampCreationPage = (): React.ReactElement => {
     switch (page) {
       case CampCreationPages.CampCreationDetailsPage:
         return (
-          <CampCreationDetails
-            campName={campName}
-            campDescription={campDescription}
-            dailyCampFee={dailyCampFee}
-            startTime={startTime}
-            endTime={endTime}
-            ageLower={ageLower}
-            ageUpper={ageUpper}
-            campCapacity={campCapacity}
-            offersEDLP={offersEDLP}
-            earliestDropOffTime={earliestDropOffTime}
-            latestPickUpTime={latestPickUpTime}
-            priceEDLP={priceEDLP}
-            addressLine1={addressLine1}
-            addressLine2={addressLine2}
-            city={city}
-            province={province}
-            postalCode={postalCode}
-            campImageURL={campImageURL}
-            handleCampName={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setCampName(event.target.value)
-            }
-            handleCampDescription={(
-              event: React.ChangeEvent<HTMLTextAreaElement>,
-            ) => setCampDescription(event.target.value)}
-            handleDailyCampFee={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setDailyCampFee(Number(event.target.value))
-            }
-            handleStartTime={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setStartTime(event.target.value)
-            }
-            handleEndTime={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setEndTime(event.target.value)
-            }
-            handleAgeLower={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setAgeLower(Number(event.target.value))
-            }
-            handleAgeUpper={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setAgeUpper(Number(event.target.value))
-            }
-            handleCampCapacity={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setCampCapacity(Number(event.target.value))
-            }
-            toggleEDLP={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setOffersEDLP(Boolean(event.target.checked))
-            }
-            handleEarliestDropOffTime={(
-              event: React.ChangeEvent<HTMLInputElement>,
-            ) => setEarliestDropOffTime(event.target.value)}
-            handleLatestPickUpTime={(
-              event: React.ChangeEvent<HTMLInputElement>,
-            ) => setLatestPickUpTime(event.target.value)}
-            handlePriceEDLP={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setPriceEDLP(Number(event.target.value))
-            }
-            handleAddressLine1={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setAddresLine1(event.target.value)
-            }
-            handleAddressLine2={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setAddresLine2(event.target.value)
-            }
-            handleCity={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setCity(event.target.value)
-            }
-            handleProvince={(event: React.ChangeEvent<HTMLSelectElement>) =>
-              setProvince(event.target.value)
-            }
-            handlePostalCode={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setPostalCode(event.target.value)
-            }
-            setCampImageURL={setCampImageURL}
-          />
+          <React.Fragment key={editCampId ? "loaded" : "loading"}>
+            <CampCreationDetails
+              campName={campName}
+              campDescription={campDescription}
+              dailyCampFee={dailyCampFee}
+              startTime={startTime}
+              endTime={endTime}
+              ageLower={ageLower}
+              ageUpper={ageUpper}
+              campCapacity={campCapacity}
+              offersEDLP={offersEDLP}
+              earliestDropOffTime={earliestDropOffTime}
+              latestPickUpTime={latestPickUpTime}
+              priceEDLP={priceEDLP}
+              addressLine1={addressLine1}
+              addressLine2={addressLine2}
+              city={city}
+              province={province}
+              postalCode={postalCode}
+              campImageURL={campImageURL}
+              handleCampName={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setCampName(event.target.value)
+              }
+              handleCampDescription={(
+                event: React.ChangeEvent<HTMLTextAreaElement>,
+              ) => setCampDescription(event.target.value)}
+              handleDailyCampFee={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setDailyCampFee(Number(event.target.value))}
+              handleStartTime={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setStartTime(event.target.value)
+              }
+              handleEndTime={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setEndTime(event.target.value)
+              }
+              handleAgeLower={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setAgeLower(Number(event.target.value))
+              }
+              handleAgeUpper={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setAgeUpper(Number(event.target.value))
+              }
+              handleCampCapacity={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setCampCapacity(Number(event.target.value))}
+              toggleEDLP={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setOffersEDLP(Boolean(event.target.checked))
+              }
+              handleEarliestDropOffTime={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setEarliestDropOffTime(event.target.value)}
+              handleLatestPickUpTime={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setLatestPickUpTime(event.target.value)}
+              handlePriceEDLP={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setPriceEDLP(Number(event.target.value))
+              }
+              handleAddressLine1={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setAddresLine1(event.target.value)}
+              handleAddressLine2={(
+                event: React.ChangeEvent<HTMLInputElement>,
+              ) => setAddresLine2(event.target.value)}
+              handleCity={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setCity(event.target.value)
+              }
+              handleProvince={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                setProvince(event.target.value)
+              }
+              handlePostalCode={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setPostalCode(event.target.value)
+              }
+              setCampImageURL={setCampImageURL}
+            />
+          </React.Fragment>
         );
       case CampCreationPages.ScheduleSessionsPage:
         return (
           <ScheduleSessions
-            campTitle={
-              campToEdit
-                ? `${campToEdit.name} @${campToEdit.startTime} - ${campToEdit.endTime}`
-                : "Waterloo Photography Camp 2022 @7:00 AM - 3:00PM"
-            }
+            campTitle={`${campName} @${startTime} - ${endTime}`}
             scheduledSessions={scheduledSessions}
             setScheduledSessions={setScheduledSessions}
           />

--- a/frontend/src/components/pages/CampOverview/Footer.tsx
+++ b/frontend/src/components/pages/CampOverview/Footer.tsx
@@ -77,6 +77,7 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
             borderColor="primary.green.100"
             variant="outline"
             p="16px"
+            onClick={() => history.push(`/admin/edit-camp/${camp.id}`)}
           >
             Edit draft
           </Button>

--- a/frontend/src/components/pages/CampOverview/Footer.tsx
+++ b/frontend/src/components/pages/CampOverview/Footer.tsx
@@ -13,6 +13,7 @@ import { CampResponse } from "../../../types/CampsTypes";
 import FooterDeleteModal from "./FooterDeleteModal";
 
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
+import { CAMP_EDIT_PAGE } from "../../../constants/Routes";
 
 type FooterProps = {
   camp: CampResponse;
@@ -46,6 +47,10 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
     onClose();
   };
 
+  const onEditCampClick = (campID: string): void => {
+    history.push(CAMP_EDIT_PAGE.replace(":id", campID));
+  };
+
   return (
     <Flex
       pos="fixed"
@@ -77,7 +82,7 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
             borderColor="primary.green.100"
             variant="outline"
             p="16px"
-            onClick={() => history.push(`/admin/edit-camp/${camp.id}`)}
+            onClick={() => onEditCampClick(camp.id)}
           >
             Edit draft
           </Button>

--- a/frontend/src/components/pages/CampOverview/index.tsx
+++ b/frontend/src/components/pages/CampOverview/index.tsx
@@ -56,6 +56,8 @@ const CampOverviewPage = (): JSX.Element => {
     campSessions: [],
     volunteers: "",
     campPhotoUrl: "",
+    dropoffFee: 0,
+    pickupFee: 0,
   });
   const numSessions = camp.campSessions?.length;
 

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -1,3 +1,6 @@
+import React, { Dispatch, SetStateAction } from "react";
+
+import { useHistory } from "react-router-dom";
 import { SearchIcon } from "@chakra-ui/icons";
 import { FaEllipsisV } from "react-icons/fa";
 import {
@@ -23,7 +26,7 @@ import {
   Thead,
   Tr,
 } from "@chakra-ui/react";
-import React, { Dispatch, SetStateAction } from "react";
+
 import { CampResponse, CampStatus } from "../../../types/CampsTypes";
 import {
   getCampStatus,
@@ -58,6 +61,8 @@ const CampsTable = ({
   const [selectedFilter, setSelectedFilter] = React.useState<CampStatus | "">(
     "",
   );
+
+  const history = useHistory();
 
   const tableData = React.useMemo(() => {
     let filteredCamps = camps;
@@ -215,6 +220,18 @@ const CampsTable = ({
                         Delete camp
                       </Text>
                     </PopoverBody>
+                    {getCampStatus(camp) === CampStatus.DRAFT && (
+                      <PopoverBody
+                        as={Button}
+                        bg="background.white.100"
+                        onClick={() =>
+                          history.push(`/admin/edit-camp/${camp.id}`)
+                        }
+                        padding="1.5em 2em"
+                      >
+                        <Text textStyle="buttonRegular">Edit camp</Text>
+                      </PopoverBody>
+                    )}
                   </PopoverContent>
                 </Popover>
               </Td>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -34,6 +34,7 @@ import {
   locationString,
 } from "../../../utils/CampUtils";
 import CampStatusLabel from "./CampStatusLabel";
+import { CAMP_EDIT_PAGE } from "../../../constants/Routes";
 
 type CampsTableProps = {
   camps: CampResponse[];
@@ -63,6 +64,10 @@ const CampsTable = ({
   );
 
   const history = useHistory();
+
+  const onEditCampClick = (campID: string): void => {
+    history.push(CAMP_EDIT_PAGE.replace(":id", campID));
+  };
 
   const tableData = React.useMemo(() => {
     let filteredCamps = camps;
@@ -224,9 +229,7 @@ const CampsTable = ({
                       <PopoverBody
                         as={Button}
                         bg="background.white.100"
-                        onClick={() =>
-                          history.push(`/admin/edit-camp/${camp.id}`)
-                        }
+                        onClick={() => onEditCampClick(camp.id)}
                         padding="1.5em 2em"
                       >
                         <Text textStyle="buttonRegular">Edit camp</Text>

--- a/frontend/src/constants/CampManagementConstants.ts
+++ b/frontend/src/constants/CampManagementConstants.ts
@@ -13,4 +13,6 @@ const MONTHS: { [key: string]: number } = {
   December: 11,
 };
 
+export const MAX_CAMP_DESC_LENGTH = 400;
+
 export default MONTHS;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -19,3 +19,5 @@ export const ACCESS_CONTROL_PAGE = "/admin/access-control";
 export const CAMP_OVERVIEW_PAGE = "/admin/camp/:id";
 
 export const CAMP_REGISTER_PAGE = "/register/camp/:id";
+
+export const CAMP_EDIT_PAGE = "/admin/edit-camp/:id";

--- a/frontend/src/types/CampsTypes.ts
+++ b/frontend/src/types/CampsTypes.ts
@@ -29,6 +29,8 @@ export type CampResponse = {
   location: Location;
   startTime: string;
   fee: number;
+  pickupFee: number;
+  dropoffFee: number;
   formQuestions: FormQuestion[];
   campSessions: CampSession[];
   volunteers: string;

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -157,12 +157,13 @@ const getWeekDayKeyFromDateNum = (num: number): string => {
   }
 };
 
-// getSelectedWeekDaysFromDates takes an array of Dates and returns the weekdays that are part of this
-// session of camp. Days without camp for this session will have a value of false
+// getSelectedWeekDaysFromDates takes an array of Dates and returns map of weekdays,
+// with value of true if camp session occurs on this weekday, otherwise false.
+// All camp sessions occur over a single week period.
 export const getSelectedWeekDaysFromDates = (
   sessionDates: Date[],
 ): Map<string, boolean> => {
-  const tempWeekDays = new Map<string, boolean>([
+  const campDays = new Map<string, boolean>([
     ["Su", false],
     ["Mo", false],
     ["Tu", false],
@@ -174,10 +175,10 @@ export const getSelectedWeekDaysFromDates = (
 
   sessionDates.forEach((date) => {
     const key = getWeekDayKeyFromDateNum(date.getDay());
-    tempWeekDays.set(key, true);
+    campDays.set(key, true);
   });
 
-  return tempWeekDays;
+  return campDays;
 };
 
 export const getMonthIndex = (month: string): number => MONTHS[month];

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -138,6 +138,48 @@ export const getFormattedCampDateRange = (
   return "";
 };
 
+const getWeekDayKeyFromDateNum = (num: number): string => {
+  switch (num) {
+    case 0:
+      return "Su";
+    case 1:
+      return "Mo";
+    case 2:
+      return "Tu";
+    case 3:
+      return "We";
+    case 4:
+      return "Th";
+    case 5:
+      return "Fr";
+    default:
+      return "Sa";
+  }
+};
+
+// getSelectedWeekDaysFromDates takes an array of Dates and returns the weekdays that are part of this
+// session of camp. Days without camp for this session will have a value of false
+export const getSelectedWeekDaysFromDates = (
+  sessionDates: Date[],
+): Map<string, boolean> => {
+  const tempWeekDays = new Map<string, boolean>([
+    ["Su", false],
+    ["Mo", false],
+    ["Tu", false],
+    ["We", false],
+    ["Th", false],
+    ["Fr", false],
+    ["Sa", false],
+  ]);
+
+  sessionDates.forEach((date) => {
+    const key = getWeekDayKeyFromDateNum(date.getDay());
+    tempWeekDays.set(key, true);
+  });
+
+  return tempWeekDays;
+};
+
 export const getMonthIndex = (month: string): number => MONTHS[month];
 
 export const getMonthName = (date: Date): string =>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Creation/Editing: Entry to editing flow](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=7c29108f44b442d79df40106b198b097&pm=c)
[Camp Edit: Populate initial camp data for edit flow](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=79665cc09fe148ca9c8a20fa795ab8cf&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* nothing crazy, just made a backend call to get the camps and then set the state of the camp creation flow to that data 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. First check the 2 entry points to edit camp: through the camp list table + through camp overview footer
2. Use the Vancouver camp as a test camp or create another draft camp to play around with
3. All the info should be preloaded on the edit-camp endpoint


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The comment on changing the key to change the defaultValue describes a (decently problematic) issue. I couldn't think of another way to handle the defaultValue changing 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
