### PR TITLE
Fix: Conditionally renders EDLP question based on state from camp details page

### DIFF
--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -326,7 +326,7 @@ const CampCreationDetails = ({
         </Box>
       </HStack>
 
-      <Checkbox marginTop="8px" onChange={toggleEDLP}>
+      <Checkbox marginTop="8px" onChange={toggleEDLP} isChecked={offersEDLP}>
         <Text textStyle="buttonSemiBold">
           Camp offers early drop-off and late pick-up
         </Text>

--- a/frontend/src/components/pages/CampCreation/RegistrationForm/index.tsx
+++ b/frontend/src/components/pages/CampCreation/RegistrationForm/index.tsx
@@ -66,10 +66,8 @@ const RegistrationFormPage = ({
   } = useDisclosure();
 
   const filteredFixedCamperInfoQuestions = campOffersEDLP
-    ? fixedCamperInfoQuestions
-    : fixedCamperInfoQuestions.filter(
-        (question) => question.question !== EDLP_CAMPER_INFO_QUESTION,
-      );
+    ? fixedCamperInfoQuestions.concat([EDLP_CAMPER_INFO_QUESTION])
+    : fixedCamperInfoQuestions;
 
   return (
     <Box mx="8vw" my="5vh">

--- a/frontend/src/components/pages/CampCreation/RegistrationForm/index.tsx
+++ b/frontend/src/components/pages/CampCreation/RegistrationForm/index.tsx
@@ -10,6 +10,7 @@ import {
 import { FormQuestion, CreateFormQuestion } from "../../../../types/CampsTypes";
 import AddQuestionModal from "../../../common/formQuestions/AddQuestionModal";
 import {
+  EDLP_CAMPER_INFO_QUESTION,
   fixedCamperInfoQuestions,
   fixedEmergencyContactQuestions,
 } from "../../../../constants/FixedQuestions";
@@ -25,6 +26,7 @@ type RegistrationFormPageProps = {
     newQuestion: CreateFormQuestion,
   ) => void;
   setVisitedRegistrationPage: React.Dispatch<React.SetStateAction<boolean>>;
+  campOffersEDLP: boolean;
 };
 
 const RegistrationFormPage = ({
@@ -34,7 +36,8 @@ const RegistrationFormPage = ({
   onDeleteCustomQuestion,
   onEditCustomQuestion,
   setVisitedRegistrationPage,
-}: RegistrationFormPageProps): JSX.Element => {
+  campOffersEDLP,
+}: RegistrationFormPageProps): React.ReactElement => {
   useEffect(() => {
     setVisitedRegistrationPage(true);
   });
@@ -62,6 +65,12 @@ const RegistrationFormPage = ({
     onClose: onAddQuestionClose,
   } = useDisclosure();
 
+  const filteredFixedCamperInfoQuestions = campOffersEDLP
+    ? fixedCamperInfoQuestions
+    : fixedCamperInfoQuestions.filter(
+        (question) => question.question !== EDLP_CAMPER_INFO_QUESTION,
+      );
+
   return (
     <Box mx="8vw" my="5vh">
       <AddQuestionModal
@@ -84,7 +93,7 @@ const RegistrationFormPage = ({
         <QuestionsAccordionItem
           accordionTitle="Camper Information"
           fixedQuestions={[
-            ...fixedCamperInfoQuestions,
+            ...filteredFixedCamperInfoQuestions,
             ...formTemplateCamperInfoQuestions,
           ]}
           dynamicQuestions={customCamperInfoQuestions as FormQuestion[]}

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -255,6 +255,7 @@ const CampCreationPage = (): React.ReactElement => {
             onDeleteCustomQuestion={onDeleteCustomQuestion}
             onEditCustomQuestion={onEditCustomQuestion}
             setVisitedRegistrationPage={setVisitedRegistrationPage}
+            campOffersEDLP={offersEDLP}
           />
         );
       default:

--- a/frontend/src/constants/FixedQuestions.ts
+++ b/frontend/src/constants/FixedQuestions.ts
@@ -2,8 +2,15 @@ import { FormQuestion } from "../types/CampsTypes";
 
 const PERSONAL_INFO = "PersonalInfo";
 const EMERGENCY_CONTACT = "EmergencyContact";
-export const EDLP_CAMPER_INFO_QUESTION =
-  "Please indicate if your child requires early dropoff and/or late pickup";
+export const EDLP_CAMPER_INFO_QUESTION: FormQuestion = {
+  type: "MultipleChoice",
+  question:
+    "Please indicate if your child requires early dropoff and/or late pickup",
+  required: true,
+  category: PERSONAL_INFO,
+  options: ["Yes", "No"],
+  id: "NONE",
+};
 
 export const fixedCamperInfoQuestions: Array<FormQuestion> = [
   {
@@ -40,14 +47,6 @@ export const fixedCamperInfoQuestions: Array<FormQuestion> = [
       "Please indicate if your child requires any additional accomodations (if not, please leave blank)",
     required: false,
     category: PERSONAL_INFO,
-    id: "NONE",
-  },
-  {
-    type: "MultipleChoice",
-    question: EDLP_CAMPER_INFO_QUESTION,
-    required: true,
-    category: PERSONAL_INFO,
-    options: ["Yes", "No"],
     id: "NONE",
   },
 ];

--- a/frontend/src/constants/FixedQuestions.ts
+++ b/frontend/src/constants/FixedQuestions.ts
@@ -2,6 +2,8 @@ import { FormQuestion } from "../types/CampsTypes";
 
 const PERSONAL_INFO = "PersonalInfo";
 const EMERGENCY_CONTACT = "EmergencyContact";
+export const EDLP_CAMPER_INFO_QUESTION =
+  "Please indicate if your child requires early dropoff and/or late pickup";
 
 export const fixedCamperInfoQuestions: Array<FormQuestion> = [
   {
@@ -42,8 +44,7 @@ export const fixedCamperInfoQuestions: Array<FormQuestion> = [
   },
   {
     type: "MultipleChoice",
-    question:
-      "Please indicate if your child requires early dropoff and/or late pickup",
+    question: EDLP_CAMPER_INFO_QUESTION,
     required: true,
     category: PERSONAL_INFO,
     options: ["Yes", "No"],


### PR DESCRIPTION


## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Creation/Editing: Conditionally Rendering EDLP Question on Registration Form](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=ea914f89233f4590afbc27a11e274cf7&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go through the create camp flow


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
