### PR TITLE
Fix: Supports optional secondary contact info rendering in campers table

### DIFF
--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -232,15 +232,17 @@ const CampersTable = ({
                     </VStack>
                   </Td>
                   <Td maxWidth="320px">
-                    <VStack align="start">
-                      <Text
-                        style={textStyles.buttonSemiBold}
-                      >{`${camper.contacts[1].firstName} ${camper.contacts[1].lastName}`}</Text>
-                      <Text>
-                        {camper.contacts[1].phoneNumber} |{" "}
-                        {camper.contacts[1].email}
-                      </Text>
-                    </VStack>
+                    {camper.contacts.length > 1 && (
+                      <VStack align="start">
+                        <Text
+                          style={textStyles.buttonSemiBold}
+                        >{`${camper.contacts[1].firstName} ${camper.contacts[1].lastName}`}</Text>
+                        <Text>
+                          {camper.contacts[1].phoneNumber} |{" "}
+                          {camper.contacts[1].email}
+                        </Text>
+                      </VStack>
+                    )}
                   </Td>
                   <Td pl="7px" maxWidth="760px">
                     <CamperDetailsBadgeGroup camper={camper} />


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Campers table: page crashes when secondary contact is not provided](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=e9a3f31a29cb47a98103a090dd69d59e&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
