### PR TITLE
Center-align status header on camps list table and access control table

### DIFF
--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -272,7 +272,9 @@ const AccessControlPage = (): JSX.Element => {
             <Th color="text.default.100">Name</Th>
             <Th color="text.default.100">Email</Th>
             <Th color="text.default.100">Role</Th>
-            <Th color="text.default.100">Status</Th>
+            <Th color="text.default.100" justifyContent="center" display="flex">
+              Status
+            </Th>
             <Th color="text.default.100"> </Th>
           </Tr>
         </Thead>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -152,7 +152,9 @@ const CampsTable = ({
           <Tr>
             <Th color="text.default.100">Camp Name</Th>
             <Th color="text.default.100">Camp Dates</Th>
-            <Th color="text.default.100">Camp Status</Th>
+            <Th color="text.default.100" justifyContent="center" display="flex">
+              Camp Status
+            </Th>
             <Th color="text.default.100"> </Th>
           </Tr>
         </Thead>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Center-align status header on camps list table and access control table](https://www.notion.so/uwblueprintexecs/Center-align-status-header-on-camps-list-table-and-access-control-table-db6f4a2c07de4b4cb50901e8b0eb7498)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go to camp list table / access control table
2. check that the `Status` header is centered


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
