### PR TITLE
fix: session card/drawer wrapping

### DIFF
--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/CurrentSessionsView.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/CurrentSessionsView.tsx
@@ -9,6 +9,8 @@ import {
   VStack,
   useToast,
   useDisclosure,
+  Wrap,
+  WrapItem,
 } from "@chakra-ui/react";
 import { CreateCampSession } from "../../../../../types/CampsTypes";
 import ScheduledSessionsCard from "./ScheduledSessionsCard";
@@ -70,12 +72,16 @@ const CurrentSessionsView = ({
         onClose={onClose}
         onDelete={confirmDeleteSession}
       />
-      <HStack justifyContent="space-between" flexWrap="wrap">
-        <Text textStyle="displayLarge">Current Sessions</Text>
-        <Button variant="secondary" onClick={() => setShowAddSessions(true)}>
-          Add more session(s)
-        </Button>
-      </HStack>
+      <Wrap justifyContent="space-between">
+        <WrapItem>
+          <Text textStyle="displayLarge">Current Sessions</Text>
+        </WrapItem>
+        <WrapItem>
+          <Button variant="secondary" onClick={() => setShowAddSessions(true)}>
+            Add more session(s)
+          </Button>
+        </WrapItem>
+      </Wrap>
       <Divider marginY={5} />
       <Box overflowY="auto" flex="1 1 0">
         <VStack alignItems="flex-start" spacing={5}>

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, HStack, Text, Button } from "@chakra-ui/react";
+import { Box, HStack, Text, Button, Wrap, WrapItem } from "@chakra-ui/react";
 import SessionDayButton from "./SessionDayButton";
 import { CreateCampSession } from "../../../../../types/CampsTypes";
 import {
@@ -81,16 +81,17 @@ const ScheduledSessionsCard = ({
         <Text marginBottom={3} textStyle="bodyRegular">
           {sessionDatesRangeString}
         </Text>
-        <HStack justify="space-between" flexWrap="wrap">
+        <Wrap>
           {Array.from(selectedWeekDays.keys()).map((day) => (
-            <SessionDayButton
-              key={day}
-              day={day}
-              selected={selectedWeekDays.get(day)}
-              onSelect={updateSelectedSessionDays}
-            />
+            <WrapItem key={day}>
+              <SessionDayButton
+                day={day}
+                selected={selectedWeekDays.get(day)}
+                onSelect={updateSelectedSessionDays}
+              />
+            </WrapItem>
           ))}
-        </HStack>
+        </Wrap>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Creation/Editing: Session Card Scaling](https://www.notion.so/uwblueprintexecs/Camp-Creation-Editing-Session-Card-Scaling-24e54d39cdba4d33bc1a4c97c3af2dff)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go to `/admin/add-camp`
2. fill out first page then go to next
3. add session and see that it wraps properly in the drawer

before:
<img width="328" alt="Screen Shot 2022-12-24 at 1 58 57 AM" src="https://user-images.githubusercontent.com/41273929/209425183-5e35d8c9-d2e2-400c-a2e2-645c132110c5.png">

after:
<img width="319" alt="Screen Shot 2022-12-24 at 1 58 21 AM" src="https://user-images.githubusercontent.com/41273929/209425175-030d5bfd-cdd0-4d34-83bc-b3ba87b965d5.png">




<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
