### PR TITLE
fix: delete camp button goes below edit on popover

### DIFF
--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -15,6 +15,7 @@ import {
   Popover,
   PopoverBody,
   PopoverContent,
+  PopoverFooter,
   PopoverTrigger,
   Table,
   Tag,
@@ -217,16 +218,6 @@ const CampsTable = ({
                     />
                   </PopoverTrigger>
                   <PopoverContent width="inherit">
-                    <PopoverBody
-                      as={Button}
-                      bg="background.white.100"
-                      onClick={() => onDeleteClick(camp)}
-                      padding="1.5em 2em"
-                    >
-                      <Text textStyle="buttonRegular" color="text.critical.100">
-                        Delete camp
-                      </Text>
-                    </PopoverBody>
                     {getCampStatus(camp) === CampStatus.DRAFT && (
                       <PopoverBody
                         as={Button}
@@ -237,6 +228,16 @@ const CampsTable = ({
                         <Text textStyle="buttonRegular">Edit camp</Text>
                       </PopoverBody>
                     )}
+                    <PopoverFooter
+                      as={Button}
+                      bg="background.white.100"
+                      onClick={() => onDeleteClick(camp)}
+                      padding="1.5em 2em"
+                    >
+                      <Text textStyle="buttonRegular" color="text.critical.100">
+                        Delete camp
+                      </Text>
+                    </PopoverFooter>
                   </PopoverContent>
                 </Popover>
               </Td>


### PR DESCRIPTION
https://github.com/uwblueprint/focus-on-nature/pull/196#discussion_r1055082277

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description

https://user-images.githubusercontent.com/40974372/209657995-aaca9e2a-8725-404f-8c1a-32cfbad25223.mov


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
