### PR TITLE
fix: Waiver clauses not loading

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
@@ -1,4 +1,3 @@
-import { WaiverClause } from "../../../../../types/AdminTypes";
 import {
   WaiverInterface,
   OptionalClauseResponse,
@@ -7,7 +6,6 @@ import {
   ClickOptionalClause,
   FillDate,
   FillName,
-  RequiredClauseResponse,
 } from "../../../../../types/waiverRegistrationTypes";
 
 export const checkName = (name: string): boolean => {
@@ -27,7 +25,7 @@ export const checkRequiredClauses = (
 export const checkOptionalClause = (
   optionalClauseResponse: OptionalClauseResponse,
 ): boolean => {
-  return optionalClauseResponse.optionSelected !== false;
+  return optionalClauseResponse.optionSelected;
 };
 
 const waiverReducer = (
@@ -36,25 +34,6 @@ const waiverReducer = (
 ): WaiverInterface => {
   const newWaiverInterface: WaiverInterface = { ...waiverInterface };
   switch (action.type) {
-    case WaiverActions.GET_CLAUSES: {
-      const optionalClauses: OptionalClauseResponse[] = [];
-      const requiredClauses: RequiredClauseResponse[] = [];
-
-      newWaiverInterface.waiver.clauses.forEach((clause: WaiverClause) => {
-        if (clause.required) requiredClauses.push(clause);
-        else
-          optionalClauses.push({
-            ...clause,
-            agreed: false,
-            optionSelected: false,
-          }); // Note that we set agreed to false by default while in actuality, the clause is neither agreed to disagreed to by default
-      });
-      newWaiverInterface.optionalClauses = optionalClauses;
-      newWaiverInterface.requiredClauses = requiredClauses;
-      newWaiverInterface.agreedRequiredClauses = false;
-      newWaiverInterface.loadingWaiver = false;
-      break;
-    }
     case WaiverActions.ClICK_REQUIRED_CLAUSE: {
       newWaiverInterface.agreedRequiredClauses = !newWaiverInterface.agreedRequiredClauses;
       break;

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
@@ -25,7 +25,7 @@ export const checkRequiredClauses = (
 export const checkOptionalClause = (
   optionalClauseResponse: OptionalClauseResponse,
 ): boolean => {
-  return optionalClauseResponse.optionSelected;
+  return optionalClauseResponse.agreed !== undefined;
 };
 
 const waiverReducer = (
@@ -49,7 +49,7 @@ const waiverReducer = (
           index: number,
         ): OptionalClauseResponse => {
           if (index === optionalClauseId) {
-            return { ...optionalClause, agreed, optionSelected: true };
+            return { ...optionalClause, agreed };
           }
           return optionalClause;
         },

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/index.tsx
@@ -210,7 +210,7 @@ const WaiverPage = ({
                     });
                   }}
                   key={index}
-                  value={String(clause.optionSelected ? clause.agreed : null)}
+                  value={String(clause.agreed)}
                 >
                   <HStack spacing={5}>
                     <Radio value="true" mb={0}>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
@@ -1,8 +1,8 @@
 import { Box, Flex } from "@chakra-ui/react";
-import React, { useState, useReducer, Reducer, useRef, useEffect } from "react";
+import React, { useState, useReducer, Reducer, useRef } from "react";
 import { CampResponse, CampSession } from "../../../../types/CampsTypes";
 import {
-  WaiverActions,
+  OptionalClauseResponse,
   WaiverInterface,
   WaiverReducerDispatch,
 } from "../../../../types/waiverRegistrationTypes";
@@ -39,10 +39,24 @@ const RegistrationSteps = ({
   >(waiverReducer, {
     campName: camp.name,
     waiver,
-    optionalClauses: [],
-    requiredClauses: [],
+    optionalClauses: waiver.clauses.reduce(
+      (optionalClauses: OptionalClauseResponse[], clause) => {
+        if (!clause.required) {
+          optionalClauses.push({
+            ...clause,
+            // Assigned a value, but the clause is neither agreed to nor disagreed to
+            // by default, until user explicitly sets a value as tracked by `optionSelected`
+            agreed: false,
+            optionSelected: false,
+          });
+        }
+
+        return optionalClauses;
+      },
+      [],
+    ),
+    requiredClauses: waiver.clauses.filter((clause) => clause.required),
     agreedRequiredClauses: false,
-    loadingWaiver: true,
     date: "",
     name: "",
     waiverCompleted: false,
@@ -82,12 +96,6 @@ const RegistrationSteps = ({
   const isWaiverFilled = waiverInterface.waiverCompleted;
   const isReviewRegistrationFilled = sampleRegisterField;
   const nextBtnRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    waiverDispatch({
-      type: WaiverActions.GET_CLAUSES,
-    });
-  }, [waiver]);
 
   const isCurrentStepCompleted = (step: RegistrantExperienceSteps) => {
     switch (step) {

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
@@ -44,10 +44,7 @@ const RegistrationSteps = ({
         if (!clause.required) {
           optionalClauses.push({
             ...clause,
-            // Assigned a value, but the clause is neither agreed to nor disagreed to
-            // by default, until user explicitly sets a value as tracked by `optionSelected`
-            agreed: false,
-            optionSelected: false,
+            agreed: undefined,
           });
         }
 

--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -55,7 +55,7 @@ const RegistrantExperiencePage = (): React.ReactElement => {
           };
         }),
       );
-  }, []);
+  }, [campId]);
 
   if (campResponse && waiverResponse) {
     return sessionSelectionIsComplete ? (

--- a/frontend/src/types/waiverRegistrationTypes.ts
+++ b/frontend/src/types/waiverRegistrationTypes.ts
@@ -42,8 +42,7 @@ export enum WaiverActions {
 }
 
 export interface OptionalClauseResponse extends WaiverClause {
-  agreed: boolean;
-  optionSelected: boolean; // Whether the registrant has seleted either "I agree" or "I disagree" for the clause
+  agreed: boolean | undefined;
 }
 
 /* eslint-disable-next-line */

--- a/frontend/src/types/waiverRegistrationTypes.ts
+++ b/frontend/src/types/waiverRegistrationTypes.ts
@@ -37,7 +37,6 @@ export interface ClickRequiredClauses extends WaiverReducerDispatchBase {}
 export enum WaiverActions {
   CLICK_OPTIONAL_CLAUSE,
   ClICK_REQUIRED_CLAUSE,
-  GET_CLAUSES,
   WRITE_NAME,
   WRITE_DATE,
 }
@@ -56,7 +55,6 @@ export type WaiverInterface = {
   optionalClauses: OptionalClauseResponse[];
   requiredClauses: RequiredClauseResponse[];
   agreedRequiredClauses: boolean;
-  loadingWaiver: boolean;
   name: string;
   date: string;
   waiverCompleted: boolean;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Original loading code was removed in https://github.com/uwblueprint/focus-on-nature/pull/214 as we load waiver in session selection. We still need to filter waiver clauses though, as seen in: https://github.com/uwblueprint/focus-on-nature/blob/fd459f3c0baf7d08668c109daefc08475e8e87a2/frontend/src/components/pages/RegistrantExperience/Waiver/WaiverReducer.tsx#L20-L35


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to waiver page, make sure everything appears as expected


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
