### PR TITLE
Camp List Table: Add a loading state when getting all the camps

### DIFF
--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -17,6 +17,7 @@ import {
   PopoverContent,
   PopoverFooter,
   PopoverTrigger,
+  Spinner,
   Table,
   Tag,
   TagLabel,
@@ -44,6 +45,7 @@ type CampsTableProps = {
   campDrawerInfo: CampResponse | undefined;
   setCampDrawerInfo: Dispatch<SetStateAction<CampResponse | undefined>>;
   onDeleteClick: (camp: CampResponse) => void;
+  loading: boolean;
 };
 
 const CampsTable = ({
@@ -53,6 +55,7 @@ const CampsTable = ({
   campDrawerInfo,
   setCampDrawerInfo,
   onDeleteClick,
+  loading,
 }: CampsTableProps): JSX.Element => {
   const filterOptions = [
     CampStatus.PUBLISHED,
@@ -245,7 +248,12 @@ const CampsTable = ({
           ))}
         </Tbody>
       </Table>
-      {tableData.length === 0 && (
+      {loading && (
+        <Center bg="background.white.100" p="30px">
+          <Spinner />
+        </Center>
+      )}
+      {!loading && tableData.length === 0 && (
         <Center
           bg="background.white.100"
           color="text.grey.600"

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -31,12 +31,15 @@ const CampsListPage = (): React.ReactElement => {
 
   const toast = useToast();
 
+  const [loading, setLoading] = React.useState(true);
+
   React.useEffect(() => {
     const getCamps = async () => {
       const res = await CampsAPIClient.getAllCamps(year);
       if (res) {
         setCamps(res);
       }
+      setLoading(false);
     };
 
     getCamps();
@@ -118,6 +121,7 @@ const CampsListPage = (): React.ReactElement => {
             campDrawerInfo={campDrawerInfo}
             setCampDrawerInfo={setCampDrawerInfo}
             onDeleteClick={onDeleteClick}
+            loading={loading}
           />
         </Box>
         <PreviewCampDrawer


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp List Table: Add a loading state when getting all the camps](https://www.notion.so/uwblueprintexecs/Camp-List-Table-Add-a-loading-state-when-getting-all-the-camps-0fc3485dea2d43178fe789239c985d43)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
