### PR TITLE
Camp edit/create CTA: Disable CTAs for camp create and edit when processing

### DIFF
--- a/frontend/src/components/pages/CampCreation/CampCreationFooter.tsx
+++ b/frontend/src/components/pages/CampCreation/CampCreationFooter.tsx
@@ -20,20 +20,26 @@ const CampCreationFooter = ({
   createUpdateCamp,
   isEditingCamp,
 }: CampCreationFooterProps): React.ReactElement => {
+  const [isAwaitingReq, setIsAwaitingReq] = React.useState(false);
+
   const onNextStep = async () => {
     handleStepNavigation(1);
 
     if (currentStep === CampCreationPages.RegistrationFormPage) {
       const isPublishedCamp = true;
       const isNewCamp = !isEditingCamp;
-      createUpdateCamp(isPublishedCamp, isNewCamp);
+      setIsAwaitingReq(true);
+      await createUpdateCamp(isPublishedCamp, isNewCamp);
+      setIsAwaitingReq(false);
     }
   };
 
-  const onSaveAsDraft = () => {
+  const onSaveAsDraft = async () => {
     const isNewCamp = !isEditingCamp;
     const isPublishedCamp = false;
-    createUpdateCamp(isPublishedCamp, isNewCamp);
+    setIsAwaitingReq(true);
+    await createUpdateCamp(isPublishedCamp, isNewCamp);
+    setIsAwaitingReq(false);
   };
 
   return (
@@ -57,6 +63,7 @@ const CampCreationFooter = ({
           height="48px"
           variant="secondary"
           onClick={() => onSaveAsDraft()}
+          isLoading={isAwaitingReq}
         >
           Save as draft
         </Button>
@@ -78,6 +85,10 @@ const CampCreationFooter = ({
         variant="primary"
         onClick={onNextStep}
         disabled={!isCurrentStepCompleted}
+        isLoading={
+          isAwaitingReq &&
+          currentStep === CampCreationPages.RegistrationFormPage
+        }
       >
         {currentStep === CampCreationPages.RegistrationFormPage
           ? "Publish"

--- a/frontend/src/components/pages/CampCreation/CampCreationFooter.tsx
+++ b/frontend/src/components/pages/CampCreation/CampCreationFooter.tsx
@@ -22,24 +22,19 @@ const CampCreationFooter = ({
 }: CampCreationFooterProps): React.ReactElement => {
   const [isAwaitingReq, setIsAwaitingReq] = React.useState(false);
 
+  const onSave = async (isPublishedCamp: boolean) => {
+    const isNewCamp = !isEditingCamp;
+    setIsAwaitingReq(true);
+    await createUpdateCamp(isPublishedCamp, isNewCamp);
+    setIsAwaitingReq(false);
+  };
+
   const onNextStep = async () => {
     handleStepNavigation(1);
 
     if (currentStep === CampCreationPages.RegistrationFormPage) {
-      const isPublishedCamp = true;
-      const isNewCamp = !isEditingCamp;
-      setIsAwaitingReq(true);
-      await createUpdateCamp(isPublishedCamp, isNewCamp);
-      setIsAwaitingReq(false);
+      onSave(true);
     }
-  };
-
-  const onSaveAsDraft = async () => {
-    const isNewCamp = !isEditingCamp;
-    const isPublishedCamp = false;
-    setIsAwaitingReq(true);
-    await createUpdateCamp(isPublishedCamp, isNewCamp);
-    setIsAwaitingReq(false);
   };
 
   return (
@@ -62,7 +57,7 @@ const CampCreationFooter = ({
           width="auto"
           height="48px"
           variant="secondary"
-          onClick={() => onSaveAsDraft()}
+          onClick={() => onSave(false)}
           isLoading={isAwaitingReq}
         >
           Save as draft

--- a/frontend/src/components/pages/CampOverview/Footer.tsx
+++ b/frontend/src/components/pages/CampOverview/Footer.tsx
@@ -28,12 +28,16 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
   const toast = useToast();
   const history = useHistory();
 
+  const [isAwaitingReq, setIsAwaitingReq] = React.useState(false);
+
   const handlePublish = async () => {
     // Ensure that we are not dealing with a published camp already
     // (should not happen due to conditional rendering, but checking to be sure)
     if (camp.active) {
       return;
     }
+
+    setIsAwaitingReq(true);
 
     // change formQuestions to CreateFormQuestions
     const newFormQuestions: CreateFormQuestionRequest[] = [];
@@ -103,6 +107,7 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
       });
     }
 
+    setIsAwaitingReq(false);
     onClose();
   };
 
@@ -126,6 +131,7 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
         color="background.white.100"
         p="16px"
         onClick={onOpen}
+        isLoading={isAwaitingReq}
       >
         Delete camp
       </Button>
@@ -151,6 +157,7 @@ const Footer = ({ camp }: FooterProps): JSX.Element => {
             color="background.white.100"
             p="16px"
             onClick={handlePublish}
+            isLoading={isAwaitingReq}
           >
             Publish camp
           </Button>

--- a/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
+++ b/frontend/src/components/pages/CampOverview/FooterDeleteModal.tsx
@@ -28,11 +28,14 @@ const FooterDeleteModal = ({
   onClose,
 }: FooterDeleteModalProps): JSX.Element => {
   const [redirect, setRedirect] = useState<boolean>(false);
+  const [isAwaitingReq, setIsAwaitingReq] = React.useState(false);
 
   const toast = useToast();
 
   const handleDeleteCamp = async () => {
+    setIsAwaitingReq(true);
     const res = await CampsAPIClient.deleteCamp(camp.id);
+    setIsAwaitingReq(false);
     if (res) {
       toast({
         description: `${camp.name} has been successfully deleted`,
@@ -88,6 +91,7 @@ const FooterDeleteModal = ({
             color="background.white.100"
             p="16px"
             onClick={handleDeleteCamp}
+            isLoading={isAwaitingReq}
           >
             Remove
           </Button>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp edit/create CTA: Disable CTAs for camp create and edit when processing](https://www.notion.so/uwblueprintexecs/Camp-edit-create-CTA-Disable-CTAs-for-camp-create-and-edit-when-processing-b5fa2a4430c44c0986ef7b921ef70f0e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* disabled both using same variable, not sure if that is intended behavior or if you just want to disable only `delete` when `delete` is clicked and not `publish`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
