### PR TITLE
[4/n] Implements payment flow

### DIFF
--- a/backend/typescript/utilities/CampUtils.ts
+++ b/backend/typescript/utilities/CampUtils.ts
@@ -3,22 +3,34 @@
 import { Camp } from "../models/camp.model";
 
 // convertCampTimingToDate returns the start and end time attached to a particular date
-export function convertCampTimingToDate(date: Date, time: string): Date {
-  const dateTime = date.toISOString();
-  const onlyDate = dateTime.split("T")[0];
-  return new Date(`${onlyDate}T${time}`);
+export function convertCampTimingToDate(
+  date: Date,
+  estStartTime: string,
+): Date {
+  const [hours, minutes] = estStartTime.split(":"); // based on 24h string like `9:30`
+  const estTimeZoneOffset = 5; // TODO consider EDT
+
+  const startTimeDate = new Date(date.getTime());
+  startTimeDate.setUTCHours(
+    parseInt(hours, 10) + estTimeZoneOffset,
+    parseInt(minutes, 10),
+  );
+  // console.log(startTimeDate);
+  return startTimeDate;
 }
 
 // Calculates total cost of early dropoff from the given timings
-export function getEDUnits(edDates: string[], camp: Camp) {
+export function getEDUnits(edDates: string[], camp: Camp): number {
   if (edDates.length === 0) return 0;
 
   const dates: Date[] = edDates.map((dateString) => new Date(dateString));
   return dates
-    .map((date) => {
-      const startTime = convertCampTimingToDate(date, camp.startTime);
+    .map((edDate) => {
+      const startTime = convertCampTimingToDate(edDate, camp.startTime);
+      console.log(edDate);
+      console.log(startTime);
       // get the number of seconds between the ED time and start time
-      let timeDiff: number = (startTime.getTime() - date.getTime()) / 1000;
+      let timeDiff: number = (startTime.getTime() - edDate.getTime()) / 1000;
       // convert to number of minutes
       timeDiff /= 60;
       // Get the number of 30 minute timeslots.
@@ -30,7 +42,7 @@ export function getEDUnits(edDates: string[], camp: Camp) {
 }
 
 // Calculates total cost of late pickup from the given timings
-export function getLPUnits(lpDates: string[], camp: Camp) {
+export function getLPUnits(lpDates: string[], camp: Camp): number {
   if (lpDates.length === 0) return 0;
 
   const dates: Date[] = lpDates.map((dateString) => new Date(dateString));

--- a/backend/typescript/utilities/CampUtils.ts
+++ b/backend/typescript/utilities/CampUtils.ts
@@ -1,0 +1,51 @@
+// The start and end time of a camp is stored as a string in format hh::mm
+
+import { Camp } from "../models/camp.model";
+
+// convertCampTimingToDate returns the start and end time attached to a particular date
+export function convertCampTimingToDate(date: Date, time: string): Date {
+  const dateTime = date.toISOString();
+  const onlyDate = dateTime.split("T")[0];
+  return new Date(`${onlyDate}T${time}`);
+}
+
+// Calculates total cost of early dropoff from the given timings
+export function getEDUnits(edDates: string[], camp: Camp) {
+  if (edDates.length === 0) return 0;
+
+  const dates: Date[] = edDates.map((dateString) => new Date(dateString));
+  return dates
+    .map((date) => {
+      const startTime = convertCampTimingToDate(date, camp.startTime);
+      // get the number of seconds between the ED time and start time
+      let timeDiff: number = (startTime.getTime() - date.getTime()) / 1000;
+      // convert to number of minutes
+      timeDiff /= 60;
+      // Get the number of 30 minute timeslots.
+      // This should always be in 30 min intervals from frontend, but we round up in case
+      const edSlots = Math.ceil(timeDiff / 30);
+      return edSlots;
+    })
+    .reduce((totalSlots, slots) => totalSlots + slots, 0);
+}
+
+// Calculates total cost of late pickup from the given timings
+export function getLPUnits(lpDates: string[], camp: Camp) {
+  if (lpDates.length === 0) return 0;
+
+  const dates: Date[] = lpDates.map((dateString) => new Date(dateString));
+
+  return dates
+    .map((lpDate) => {
+      const endTime = convertCampTimingToDate(lpDate, camp.endTime);
+      // get the number of seconds between the ED time and start time
+      let timeDiff: number = (lpDate.getTime() - endTime.getTime()) / 1000;
+      // convert to number of minutes
+      timeDiff /= 60;
+      // Get the number of 30 minute timeslots.
+      // This should always be in 30 min intervals from frontend, but we round up in case
+      const lpSlots = Math.ceil(timeDiff / 30);
+      return lpSlots;
+    })
+    .reduce((totalSlots, slots) => totalSlots + slots, 0);
+}

--- a/backend/typescript/utilities/stripeUtils.ts
+++ b/backend/typescript/utilities/stripeUtils.ts
@@ -1,6 +1,8 @@
 import Stripe from "stripe";
+import { Camp } from "../models/camp.model";
 import { CampSession } from "../models/campSession.model";
 import { CreateCampersDTO } from "../types";
+import { getEDUnits, getLPUnits } from "./CampUtils";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_TEST_KEY ?? "", {
   apiVersion: "2020-08-27",
@@ -95,56 +97,31 @@ export async function createStripePrice(
 export const createStripeLineItems = (
   sessionsToRegister: CampSession[],
   campers: CreateCampersDTO,
-  dropoffPriceId: string,
-  pickupPriceId: string,
+  camp: Camp,
 ): Stripe.Checkout.SessionCreateParams.LineItem[] => {
   return sessionsToRegister.flatMap((campSession) => {
     const priceItems = [
       { price: campSession.campPriceId, quantity: campers.length },
     ];
 
-    // every camper belongs to every session
-    // all same EDLP price
-    // campers have different EDLP dates, which may belong to different sessions
-    // we want to isolate EDLP per session
-
-    // Assumes that campers are only registered for one session per day
     const [earlyDropoffs, latePickups] = campers.reduce(
-      ([earlyTotal, lateTotal]: [number, number], camper) => {
-        let camperEarlyTotal = 0;
-        if (camper.earlyDropoff) {
-          const camperEDDates = new Set(camper.earlyDropoff);
-          const edDates = campSession.dates.filter((date) =>
-            camperEDDates.has(date.toString()),
-          );
-
-          camperEarlyTotal += edDates.length;
-        }
-
-        let camperLateTotal = 0;
-        if (camper.latePickup) {
-          const camperLPDates = new Set(camper.latePickup);
-          const lpDates = campSession.dates.filter((date) =>
-            camperLPDates.has(date.toString()),
-          );
-          camperLateTotal += lpDates.length;
-        }
-
-        return [earlyTotal + camperEarlyTotal, lateTotal + camperLateTotal];
-      },
+      ([earlyTotal, lateTotal]: [number, number], camper) => [
+        earlyTotal + getEDUnits(camper.earlyDropoff, camp),
+        lateTotal + getLPUnits(camper.latePickup, camp),
+      ],
       [0, 0],
     );
 
     if (earlyDropoffs) {
       priceItems.push({
-        price: dropoffPriceId,
+        price: camp.dropoffPriceId,
         quantity: earlyDropoffs,
       });
     }
 
     if (latePickups) {
       priceItems.push({
-        price: pickupPriceId,
+        price: camp.pickupPriceId,
         quantity: latePickups,
       });
     }

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/RegistrationErrorModal.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/RegistrationErrorModal.tsx
@@ -1,0 +1,60 @@
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import React from "react";
+import { ModalBody } from "react-bootstrap";
+import { modalBodyStyles, modalHeadingStyles } from "./textStyles";
+
+type RegistrationErrorModalProps = {
+  onConfirm: () => void;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const RegistrationErrorModal = ({
+  onConfirm,
+  isOpen,
+  onClose,
+}: RegistrationErrorModalProps): React.ReactElement => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle={modalHeadingStyles}>Payment cancelled</Text>
+        </ModalHeader>
+        <ModalBody>
+          <Text textStyle={modalBodyStyles} px="8px">
+            No payment was processed. If this was not intentional, please try
+            again.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <HStack direction="row" w="100%" justify="flex-end" spacing={3}>
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {
+                onClose();
+                onConfirm();
+              }}
+            >
+              Go back to checkout
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default RegistrationErrorModal;

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/RegistrationInfoCard.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/RegistrationInfoCard.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Flex, Image, VStack, Text } from "@chakra-ui/react";
+import { RegistrantExperienceCamper } from "../../../../types/CamperTypes";
+
+import defaultCampImage from "../../../../assets/default_camp_image.png";
+import { cardBoldStyles, regularTextStyles } from "./textStyles";
+
+export type RegistrationInfoCardProps = {
+  imageSrc: string;
+  campName: string;
+  sessions: string;
+  registeredCampers: RegistrantExperienceCamper[];
+};
+
+const RegistrationInfoCard = ({
+  imageSrc,
+  campName,
+  sessions,
+  registeredCampers,
+}: RegistrationInfoCardProps): React.ReactElement => {
+  const formatCamperData = (camper: RegistrantExperienceCamper): string =>
+    `${camper.firstName} (Age ${camper.age})`;
+
+  // Produces formatted list of campers; eg. "Campers registered: John (Age 8) and Jane (Age 4)"
+  const formatRegisteredCampers = (
+    campers: RegistrantExperienceCamper[],
+  ): string => {
+    let campersString = "Campers registered: ";
+    if (campers.length === 1) {
+      campersString += formatCamperData(campers[0]);
+    } else if (campers.length === 2) {
+      campersString += `${formatCamperData(campers[0])} and ${formatCamperData(
+        campers[1],
+      )}`;
+    } else {
+      campersString += campers.reduce(
+        (namesString, camper, index) =>
+          `${namesString}${index === 0 ? "" : ","} ${
+            index + 1 === campers.length ? "and " : ""
+          }${camper.firstName} (Age ${camper.age})`,
+        "",
+      );
+    }
+
+    return campersString;
+  };
+
+  return (
+    <Flex
+      direction="row"
+      justify="space-between"
+      align="center"
+      w="100%"
+      border="1px solid"
+      borderColor="border.default.100"
+      borderRadius="10px"
+      backgroundColor="background.grey.200"
+      py={10}
+      px={5}
+      flexWrap="wrap"
+    >
+      <Image
+        fallbackSrc={defaultCampImage}
+        src={imageSrc}
+        alt="Camp image"
+        w={{ base: "192px", lg: "6vw" }}
+        h={{ base: "122px", lg: "6vh" }}
+        mb={{ sm: 5 }}
+      />
+      <VStack align="flex-start" spacing={2} w={{ lg: "25vw" }}>
+        <Text textStyle={cardBoldStyles}>{campName}</Text>
+        <Text textStyle={regularTextStyles}>{sessions}</Text>
+        <Text textStyle={{ base: "xSmallMedium", lg: "displaySmallSemiBold" }}>
+          {formatRegisteredCampers(registeredCampers)}
+        </Text>
+      </VStack>
+    </Flex>
+  );
+};
+
+export default RegistrationInfoCard;

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect } from "react";
 import { Text, Flex, VStack, HStack } from "@chakra-ui/react";
-import { CartItem } from "../../../../types/RegistrationTypes";
+import { CartItem, EdlpChoice } from "../../../../types/RegistrationTypes";
 
-import { calculateTotalPrice } from "../../../../utils/RegistrationUtils";
+import {
+  calculateTotalPrice,
+  mapCampToCartItems,
+} from "../../../../utils/RegistrationUtils";
 import RegistrationInfoCard from "./RegistrationInfoCard";
 import {
   cardBoldStyles,
@@ -11,7 +14,7 @@ import {
   resultTitleStyles,
   subheadingStyles,
 } from "./textStyles";
-import { CampResponse } from "../../../../types/CampsTypes";
+import { CampResponse, CampSession } from "../../../../types/CampsTypes";
 import { RegistrantExperienceCamper } from "../../../../types/CamperTypes";
 import CamperAPIClient from "../../../../APIClients/CamperAPIClient";
 
@@ -58,14 +61,16 @@ const PaymentSummaryList = ({
 type RegistrationResultProps = {
   camp?: CampResponse;
   campers?: RegistrantExperienceCamper[];
-  items?: CartItem[];
+  sessions?: CampSession[];
+  edlpChoices?: EdlpChoice[][];
   chargeId?: string;
 };
 
 const RegistrationResult = ({
   camp,
   campers,
-  items,
+  sessions,
+  edlpChoices,
   chargeId,
 }: RegistrationResultProps): React.ReactElement => {
   useEffect(() => {
@@ -81,7 +86,7 @@ const RegistrationResult = ({
       mx={{ sm: "20px", md: "40px", lg: "10vw" }}
       my={{ base: "64px", lg: "10vh" }}
     >
-      {camp && campers && items && chargeId ? (
+      {camp && campers && sessions && edlpChoices && chargeId ? (
         <>
           <Text textStyle={resultTitleStyles}>Thank you for registering!</Text>
           <Text
@@ -126,7 +131,9 @@ const RegistrationResult = ({
               >
                 Payment Summary
               </Text>
-              <PaymentSummaryList items={items} />
+              <PaymentSummaryList
+                items={mapCampToCartItems(camp, sessions, campers, edlpChoices)}
+              />
             </VStack>
           </Flex>
         </>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect } from "react";
+import { Text, Flex, VStack, HStack } from "@chakra-ui/react";
+import { CartItem } from "../../../../types/RegistrationTypes";
+
+import { calculateTotalPrice } from "../../../../utils/RegistrationUtils";
+import RegistrationInfoCard from "./RegistrationInfoCard";
+import {
+  cardBoldStyles,
+  regularTextStyles,
+  resultTextStyles,
+  resultTitleStyles,
+  subheadingStyles,
+} from "./textStyles";
+import { CampResponse } from "../../../../types/CampsTypes";
+import { RegistrantExperienceCamper } from "../../../../types/CamperTypes";
+import CamperAPIClient from "../../../../APIClients/CamperAPIClient";
+
+const NoSessionDataFound = (): React.ReactElement => {
+  return (
+    <>
+      <Text textStyle={resultTitleStyles}>No checkout session data found</Text>
+      <Text
+        mt={{ sm: "6px", md: "32px", lg: "20px" }}
+        textStyle={resultTextStyles}
+      >
+        Cannot load session data. If you expect to see a success message, please
+        check your email. You should receive a payment receipt within 15
+        minutes, including more details about your registration.
+      </Text>
+    </>
+  );
+};
+
+const PaymentSummaryList = ({
+  items,
+}: {
+  items: CartItem[];
+}): React.ReactElement => {
+  return (
+    <VStack w={{ base: "100%", lg: "35vw" }} spacing={10}>
+      <VStack w="100%" overflowY="auto" h={{ lg: "35vh" }} spacing={8}>
+        {/* TODO switch to sum of EDLP, non-EDLP items */}
+        {items.map((item, index) => (
+          <HStack w="100%" justify="space-between" key={index}>
+            <Text textStyle={regularTextStyles}>{item.name}</Text>
+            <Text textStyle={regularTextStyles}>${item.totalPrice}</Text>
+          </HStack>
+        ))}
+      </VStack>
+      <HStack w="100%" justify="space-between">
+        <Text textStyle={cardBoldStyles}>Total</Text>
+        <Text textStyle={cardBoldStyles}>${calculateTotalPrice(items)}</Text>
+      </HStack>
+    </VStack>
+  );
+};
+
+type RegistrationResultProps = {
+  camp?: CampResponse;
+  campers?: RegistrantExperienceCamper[];
+  items?: CartItem[];
+  chargeId?: string;
+};
+
+const RegistrationResult = ({
+  camp,
+  campers,
+  items,
+  chargeId,
+}: RegistrationResultProps): React.ReactElement => {
+  useEffect(() => {
+    if (chargeId) {
+      CamperAPIClient.confirmPayment(chargeId);
+    }
+  }, [chargeId]);
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      mx={{ sm: "20px", md: "40px", lg: "10vw" }}
+      my={{ base: "64px", lg: "10vh" }}
+    >
+      {camp && campers && items && chargeId ? (
+        <>
+          <Text textStyle={resultTitleStyles}>Thank you for registering!</Text>
+          <Text
+            mt={{ sm: "6px", md: "32px", lg: "20px" }}
+            textStyle={resultTextStyles}
+          >
+            You should receive a payment receipt in your email within 15
+            minutes, including more details about your registration.
+          </Text>
+          <Flex
+            direction={{ sm: "column", lg: "row" }}
+            align={{ base: "center", lg: "flex-start" }}
+            justify={{ lg: "space-between" }}
+            w="100%"
+            mt={{ sm: "32px", md: "32px", lg: "64px" }}
+            flexWrap="wrap"
+          >
+            <VStack align="flex-start" w={{ base: "100%", lg: "35vw" }}>
+              <Text
+                color="text.success.100"
+                textStyle={subheadingStyles}
+                mb="20px"
+              >
+                Registration Information
+              </Text>
+              <RegistrationInfoCard
+                imageSrc="src"
+                campName={camp.name}
+                sessions="Session 1 - Aug 5 to Aug 8\nSession 2 - Aug 12 to Aug 15"
+                registeredCampers={campers}
+              />
+            </VStack>
+            <VStack
+              align="flex-start"
+              w={{ base: "100%", lg: "35vw" }}
+              mt={{ base: "32px", lg: "0px" }}
+            >
+              <Text
+                color="text.success.100"
+                textStyle={subheadingStyles}
+                mb="20px"
+              >
+                Payment Summary
+              </Text>
+              <PaymentSummaryList items={items} />
+            </VStack>
+          </Flex>
+        </>
+      ) : (
+        <NoSessionDataFound />
+      )}
+    </Flex>
+  );
+};
+
+export default RegistrationResult;

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/textStyles.ts
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/textStyles.ts
@@ -1,0 +1,38 @@
+export const resultTitleStyles = {
+  sm: "xSmallBold",
+  md: "bodyBold",
+  lg: "displayLarge",
+};
+
+export const resultTextStyles = {
+  sm: "xSmallMedium",
+  md: "xSmallMedium",
+  lg: "displayMediumRegular",
+};
+
+export const subheadingStyles = {
+  sm: "xSmallBold",
+  md: "captionSemiBold",
+  lg: "displayLarge",
+};
+
+export const cardBoldStyles = {
+  base: "xSmallBold",
+  lg: "displayMediumBold",
+};
+
+export const regularTextStyles = {
+  base: "xSmallRegular",
+  lg: "displaySmallRegular",
+};
+
+export const modalHeadingStyles = {
+  sm: "xSmallBold",
+  md: "heading",
+  lg: "heading",
+};
+
+export const modalBodyStyles = {
+  base: "bodyRegular",
+  sm: "xSmallRegular",
+};

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/edlpSessionRegistration.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/edlpSessionRegistration.tsx
@@ -21,6 +21,7 @@ import {
   getFormattedSingleDateString,
 } from "../../../../../utils/CampUtils";
 import { EdlpChoice } from "../../../../../types/RegistrationTypes";
+import { EDLP_PLACEHOLDER_TIMESLOT } from "../../../../../constants/RegistrationConstants";
 
 type EDLPSessionRegistrationProps = {
   selectedSessionIndex: number;
@@ -81,11 +82,11 @@ const EDLPSessionRegistration = ({
   edlpChoices,
   setEdlpChoices,
 }: EDLPSessionRegistrationProps): React.ReactElement => {
-  const edIntervals = ["-"].concat(
+  const edIntervals = [EDLP_PLACEHOLDER_TIMESLOT].concat(
     computeIntervals(camp.startTime, camp.earlyDropoff, false),
   );
 
-  const lpIntervals = ["-"].concat(
+  const lpIntervals = [EDLP_PLACEHOLDER_TIMESLOT].concat(
     computeIntervals(camp.endTime, camp.latePickup, true),
   );
 
@@ -147,7 +148,9 @@ const EDLPSessionRegistration = ({
       // edIntervals look like this: ["-", "8:00", "8:30", "9:00", "9:30"] for a start time of 10:00 and ed starting at 8:00
       // numSlots determines how many 30 min slots of ED the option equates to
       const numSlots =
-        edInterval === "-" ? 0 : edIntervals.length - intervalIndex;
+        edInterval === EDLP_PLACEHOLDER_TIMESLOT
+          ? 0
+          : edIntervals.length - intervalIndex;
       return (
         <option key={`${day}_edOption_${intervalIndex}`} value={numSlots}>
           {edInterval}
@@ -166,6 +169,21 @@ const EDLPSessionRegistration = ({
         </option>
       );
     });
+
+  const getDefaultSelectOption = (
+    dateIndex: number,
+    isLatePickup: boolean,
+  ): number => {
+    const interval = isLatePickup
+      ? edlpChoices[selectedSessionIndex][dateIndex].latePickup.timeSlot
+      : edlpChoices[selectedSessionIndex][dateIndex].earlyDropoff.timeSlot;
+    if (isLatePickup) {
+      return lpIntervals.indexOf(interval);
+    }
+    return interval === EDLP_PLACEHOLDER_TIMESLOT
+      ? 0
+      : edIntervals.length - edIntervals.indexOf(interval);
+  };
 
   return (
     <AccordionItem
@@ -244,10 +262,10 @@ const EDLPSessionRegistration = ({
                       <Td border="none" padding="3px">
                         <Select
                           width="120px"
-                          defaultValue={
-                            edlpChoices[selectedSessionIndex][dateIndex]
-                              .earlyDropoff.timeSlot
-                          }
+                          defaultValue={getDefaultSelectOption(
+                            dateIndex,
+                            false,
+                          )}
                           onChange={(event) => {
                             onSelectEDLP(
                               Number(event.target.value),
@@ -265,10 +283,7 @@ const EDLPSessionRegistration = ({
                       <Td border="none" padding="3px">
                         <Select
                           width="120px"
-                          defaultValue={
-                            edlpChoices[selectedSessionIndex][dateIndex]
-                              .latePickup.timeSlot
-                          }
+                          defaultValue={getDefaultSelectOption(dateIndex, true)}
                           onChange={(event) => {
                             onSelectEDLP(
                               Number(event.target.value),
@@ -317,10 +332,7 @@ const EDLPSessionRegistration = ({
                 <Select
                   minWidth="120px"
                   marginTop="8px"
-                  defaultValue={
-                    edlpChoices[selectedSessionIndex][dateIndex].earlyDropoff
-                      .timeSlot
-                  }
+                  defaultValue={getDefaultSelectOption(dateIndex, true)}
                   onChange={(event) => {
                     onSelectEDLP(
                       Number(event.target.value),
@@ -340,10 +352,7 @@ const EDLPSessionRegistration = ({
                 <Select
                   minWidth="120px"
                   marginTop="8px"
-                  defaultValue={
-                    edlpChoices[selectedSessionIndex][dateIndex].latePickup
-                      .timeSlot
-                  }
+                  defaultValue={getDefaultSelectOption(dateIndex, true)}
                   onChange={(event) => {
                     onSelectEDLP(
                       Number(event.target.value),

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/index.tsx
@@ -4,10 +4,11 @@ import { Box, Divider, Text, VStack, Accordion } from "@chakra-ui/react";
 
 import { RegistrantExperienceCamper } from "../../../../../types/CamperTypes";
 import { CampResponse, CampSession } from "../../../../../types/CampsTypes";
-import EdlpSessionRegistration, { EdlpChoice } from "./edlpSessionRegistration";
+import EdlpSessionRegistration from "./edlpSessionRegistration";
 import { useAdditionalInfoDispatcher } from "./additionalInfoReducer";
 import CamperQuestionsCard from "./QuestionCards/CamperQuestionsCard";
 import EarlyDropOffLatePickupCard from "./QuestionCards/EarlyDropOffLatePickupCard";
+import { EdlpChoice } from "../../../../../types/RegistrationTypes";
 
 type AdditionalInfoProps = {
   selectedSessions: CampSession[];
@@ -117,7 +118,8 @@ const AdditionalInfo = ({
                           key={`session_${campSession.id}_edlp`}
                           selectedSessionIndex={campSessionIndex}
                           camp={camp}
-                          edlpCost={camp.pickupFee}
+                          edCost={camp.dropoffFee}
+                          lpCost={camp.pickupFee}
                           session={campSession}
                           edlpChoices={edlpChoices}
                           setEdlpChoices={setEdlpChoices}

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Flex } from "@chakra-ui/react";
+import { Button, Flex, useToast } from "@chakra-ui/react";
 import RegistrantExperienceSteps from "./RegistrationExperienceSteps";
 
 export type RegistrationFooterProps = {
@@ -17,13 +17,21 @@ const RegistrationFooter = ({
   registrationLoading,
   handleStepNavigation,
 }: RegistrationFooterProps): React.ReactElement => {
+  const toast = useToast();
+
   const onNextStep = () => {
     if (isCurrentStepCompleted) {
       handleStepNavigation(1);
     } else {
-      alert(
-        "Form does not pass validation. Please complete all form fields according to requirements.",
-      );
+      toast({
+        title: "Form does not pass validation.",
+        description:
+          "Please complete all form fields according to requirements.",
+        variant: "subtle",
+        duration: 3000,
+        status: "error",
+        position: "top",
+      });
     }
   };
 

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
@@ -6,6 +6,7 @@ export type RegistrationFooterProps = {
   nextBtnRef: React.RefObject<HTMLButtonElement>;
   currentStep: RegistrantExperienceSteps;
   isCurrentStepCompleted: boolean;
+  registrationLoading: boolean;
   handleStepNavigation: (stepsToMove: number) => void;
 };
 
@@ -13,6 +14,7 @@ const RegistrationFooter = ({
   nextBtnRef,
   currentStep,
   isCurrentStepCompleted,
+  registrationLoading,
   handleStepNavigation,
 }: RegistrationFooterProps): React.ReactElement => {
   const onNextStep = () => {
@@ -20,7 +22,7 @@ const RegistrationFooter = ({
       handleStepNavigation(1);
     } else {
       alert(
-        "Form does not pass validaiton. Please complete all form fields according to requirements.",
+        "Form does not pass validation. Please complete all form fields according to requirements.",
       );
     }
   };
@@ -46,6 +48,7 @@ const RegistrationFooter = ({
         onClick={() => handleStepNavigation(-1)}
         mb={{ sm: 4, md: 0 }}
         mr={{ sm: 0, md: 4 }}
+        disabled={registrationLoading}
       >
         Back
       </Button>
@@ -54,6 +57,8 @@ const RegistrationFooter = ({
         width={{ sm: "95vw", md: "45vw", lg: "auto" }}
         height="48px"
         variant="primary"
+        isLoading={registrationLoading}
+        loadingText="Submitting"
         onClick={onNextStep}
       >
         {currentStep === RegistrantExperienceSteps.ReviewRegistrationPage

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/PaymentSummary.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/PaymentSummary.tsx
@@ -62,7 +62,7 @@ const PaymentSummary = ({
       <TableContainer
         mb={5}
         mt={8}
-        maxW={{ base: "100%", lg: "50%" }}
+        maxW={{ base: "100%", lg: "60%" }}
         h={{ lg: "35vh" }}
         overflowY={{ base: "visible", lg: "auto" }}
       >
@@ -131,14 +131,14 @@ const PaymentSummary = ({
       <Divider
         borderBottom="2px"
         borderColor="border.secondary.100"
-        w={{ base: "100%", lg: "50%" }}
+        w={{ base: "100%", lg: "60%" }}
       />
 
       <Flex
         direction="row"
         justify="space-between"
         my={4}
-        w={{ base: "100%", lg: "30%" }}
+        w={{ base: "100%", lg: "450px" }}
       >
         <Text textStyle={totalRowTextStyles}>Total</Text>
         <Text textStyle={totalRowTextStyles}>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/index.tsx
@@ -3,18 +3,23 @@ import { Box } from "@chakra-ui/react";
 import PaymentSummary from "./PaymentSummary";
 import ReviewInformation from "./ReviewInformation";
 import { RegistrantExperienceCamper } from "../../../../../types/CamperTypes";
-import { CampResponse } from "../../../../../types/CampsTypes";
+import { CampResponse, CampSession } from "../../../../../types/CampsTypes";
 import { mapCampToCartItems } from "../../../../../utils/RegistrationUtils";
+import { EdlpChoice } from "../../../../../types/RegistrationTypes";
 
 type ReviewRegistrationProps = {
   campers: RegistrantExperienceCamper[];
+  sessions: CampSession[];
   camp: CampResponse;
+  edlpChoices: EdlpChoice[][];
   onPageVisited: () => void;
 };
 
 const ReviewRegistration = ({
   campers,
+  sessions,
   camp,
+  edlpChoices,
   onPageVisited,
 }: ReviewRegistrationProps): React.ReactElement => {
   useEffect(() => onPageVisited());
@@ -22,7 +27,7 @@ const ReviewRegistration = ({
     <Box>
       <PaymentSummary
         campName={camp.name}
-        items={mapCampToCartItems(camp, campers)}
+        items={mapCampToCartItems(camp, sessions, campers, edlpChoices)}
       />
 
       {/* <ReviewInformation /> */}

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/index.tsx
@@ -1,62 +1,29 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import PaymentSummary from "./PaymentSummary";
-import { CartItem } from "../../../../../types/RegistrationTypes";
 import ReviewInformation from "./ReviewInformation";
+import { RegistrantExperienceCamper } from "../../../../../types/CamperTypes";
+import { CampResponse } from "../../../../../types/CampsTypes";
+import { mapCampToCartItems } from "../../../../../utils/RegistrationUtils";
 
 type ReviewRegistrationProps = {
-  isChecked: boolean;
-  toggleChecked: () => void;
-  campName: string;
+  campers: RegistrantExperienceCamper[];
+  camp: CampResponse;
+  onPageVisited: () => void;
 };
 
-const items: CartItem[] = [
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-    details: "Some sample details",
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-  {
-    name: "yes",
-    campers: 2,
-    totalPrice: 15.5,
-  },
-];
-
 const ReviewRegistration = ({
-  isChecked,
-  toggleChecked,
-  campName,
+  campers,
+  camp,
+  onPageVisited,
 }: ReviewRegistrationProps): React.ReactElement => {
+  useEffect(() => onPageVisited());
   return (
     <Box>
-      <PaymentSummary campName={campName} items={items} />
+      <PaymentSummary
+        campName={camp.name}
+        items={mapCampToCartItems(camp, campers)}
+      />
 
       {/* <ReviewInformation /> */}
     </Box>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
@@ -1,3 +1,4 @@
+import { Waiver } from "../../../../../types/AdminTypes";
 import {
   WaiverInterface,
   OptionalClauseResponse,
@@ -6,6 +7,7 @@ import {
   ClickOptionalClause,
   FillDate,
   FillName,
+  SetWaiverInterace,
 } from "../../../../../types/waiverRegistrationTypes";
 
 export const checkName = (name: string): boolean => {
@@ -32,8 +34,13 @@ const waiverReducer = (
   waiverInterface: WaiverInterface,
   action: WaiverReducerDispatch,
 ): WaiverInterface => {
-  const newWaiverInterface: WaiverInterface = { ...waiverInterface };
+  let newWaiverInterface: WaiverInterface = { ...waiverInterface };
   switch (action.type) {
+    case WaiverActions.SET_WAIVER_INTERFACE: {
+      const { waiver } = action as SetWaiverInterace;
+      newWaiverInterface = waiver;
+      break;
+    }
     case WaiverActions.ClICK_REQUIRED_CLAUSE: {
       newWaiverInterface.agreedRequiredClauses = !newWaiverInterface.agreedRequiredClauses;
       break;

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/Waiver/WaiverReducer.tsx
@@ -1,4 +1,3 @@
-import { Waiver } from "../../../../../types/AdminTypes";
 import {
   WaiverInterface,
   OptionalClauseResponse,

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
@@ -24,6 +24,7 @@ import CamperAPIClient from "../../../../APIClients/CamperAPIClient";
 import RegistrationErrorModal from "../RegistrationResult/RegistrationErrorModal";
 import { checkAdditionalQuestionsAnswered } from "./AdditionalInfo/additionalInfoReducer";
 import { mapToCreateCamperDTO } from "../../../../utils/CampUtils";
+import { EDLP_PLACEHOLDER_TIMESLOT } from "../../../../constants/RegistrationConstants";
 
 type RegistrationStepsProps = {
   camp: CampResponse;
@@ -88,8 +89,16 @@ const RegistrationSteps = ({
       return campSession.dates.map((date) => {
         return {
           date,
-          earlyDropoff: { timeSlot: "-", units: 0, cost: 0 },
-          latePickup: { timeSlot: "-", units: 0, cost: 0 },
+          earlyDropoff: {
+            timeSlot: EDLP_PLACEHOLDER_TIMESLOT,
+            units: 0,
+            cost: 0,
+          },
+          latePickup: {
+            timeSlot: EDLP_PLACEHOLDER_TIMESLOT,
+            units: 0,
+            cost: 0,
+          },
         };
       });
     }),
@@ -160,13 +169,15 @@ const RegistrationSteps = ({
         checkoutSessionUrl,
         campers: campersResponse,
       } = await CamperAPIClient.registerCampers(
-        mapToCreateCamperDTO(newCampers, edlp),
+        mapToCreateCamperDTO(newCampers, edlp, waiverInterface.optionalClauses),
         selectedSessions.map((cs) => cs.id),
       );
 
       setRegistrationLoading(false);
       goToCheckout(checkoutSessionUrl, campersResponse[0].chargeId);
     } catch (error: Error | unknown) {
+      setRegistrationLoading(false);
+
       let errorMessage =
         "Unable to create a checkout session. Please try again.";
       if (error instanceof Error) {

--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -12,7 +12,6 @@ import RegistrationResultPage from "./RegistrationResult";
 import RegistrationSteps from "./RegistrationSteps";
 import SessionSelection from "./SessionSelection";
 import { Waiver as WaiverType } from "../../../types/AdminTypes";
-import { WaiverInterface } from "../../../types/waiverRegistrationTypes";
 
 type InitialLoadingState = {
   waiver: boolean;
@@ -104,6 +103,7 @@ const RegistrantExperiencePage = (): React.ReactElement => {
           camp?.campSessions.filter((session) => sessionsIds.has(session.id)) ??
           []
         }
+        edlpChoices={restoredRegistration?.edlpChoices}
         chargeId={restoredRegistration?.chargeId}
       />
     );

--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -1,13 +1,20 @@
+import { useLocation, useParams } from "react-router-dom";
 import React, { useEffect, useState } from "react";
-import { Text, Spinner, Flex } from "@chakra-ui/react";
-import { useParams } from "react-router-dom";
 
+import { Text, Spinner, Flex } from "@chakra-ui/react";
+import AdminAPIClient from "../../../APIClients/AdminAPIClient";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
 import { CampResponse } from "../../../types/CampsTypes";
+import { SUCCESS_RESULT_CODE } from "../../../constants/RegistrationConstants";
+import {
+  mapCampToCartItems,
+  restoreRegistrationSessionFromSessionStorage,
+} from "../../../utils/RegistrationUtils";
+import { CheckoutData } from "../../../types/RegistrationTypes";
+import RegistrationResultPage from "./RegistrationResult";
 import RegistrationSteps from "./RegistrationSteps";
 import SessionSelection from "./SessionSelection";
-import AdminAPIClient from "../../../APIClients/AdminAPIClient";
-import { Waiver } from "../../../types/AdminTypes";
+import { Waiver as WaiverType } from "../../../types/AdminTypes";
 
 type InitialLoadingState = {
   waiver: boolean;
@@ -17,13 +24,12 @@ type InitialLoadingState = {
 const RegistrantExperiencePage = (): React.ReactElement => {
   const { id: campId } = useParams<{ id: string }>();
 
-  const [campResponse, setCampResponse] = useState<CampResponse | undefined>(
-    undefined,
-  );
-  const [waiverResponse, setWaiverResponse] = useState<Waiver | undefined>(
-    undefined,
-  );
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const registrationResult = params.get("result");
 
+  const [camp, setCamp] = useState<CampResponse | undefined>(undefined);
+  const [waiver, setWaiver] = useState<WaiverType | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<InitialLoadingState>({
     waiver: true,
     camp: true,
@@ -36,40 +42,88 @@ const RegistrantExperiencePage = (): React.ReactElement => {
     false,
   );
 
+  const [restoredRegistration, setRestoredRegistration] = useState<
+    CheckoutData | undefined
+  >(undefined);
+
   useEffect(() => {
-    CampsAPIClient.getCampById(campId)
-      .then((camp) => (camp.id ? setCampResponse(camp) : null))
-      .finally(() =>
-        setIsLoading((i) => {
-          return { ...i, camp: false };
-        }),
-      );
+    // We could remove this conditional, if we want to handle the "navigate back" action
+    let cachedRegistration: CheckoutData | undefined;
+    if (registrationResult) {
+      cachedRegistration = restoreRegistrationSessionFromSessionStorage();
 
-    AdminAPIClient.getWaiver()
-      .then((waiver) => (waiver.clauses ? setWaiverResponse(waiver) : null))
-      .finally(() =>
-        setIsLoading((i) => {
-          return {
-            ...i,
-            waiver: false,
-          };
-        }),
-      );
-  }, [campId]);
+      if (cachedRegistration) {
+        // Some data is expected by the default camp registration flow, and is
+        // passed through individual state variables. Data generated in the previous
+        // session (eg. checkout URL) is passed via `restoredRegistration` field,
+        // which is `undefined` if by default if no previous sessions exists.
+        setRestoredRegistration(cachedRegistration);
 
-  if (campResponse && waiverResponse) {
+        setSelectedSessions(new Set(cachedRegistration.selectedSessionIds));
+        setSessionSelectionIsComplete(true);
+        setCamp(cachedRegistration.camp);
+        setWaiver(cachedRegistration.waiver);
+      }
+    }
+
+    // If we expect session cache to exist, and it doesn't exist, do not repopulate
+    // via network call -- instead show generic message in RegistrationResult in case
+    // the user entered `?result=success` manually into the URL (so no actually success)
+    if (!cachedRegistration && registrationResult !== SUCCESS_RESULT_CODE) {
+      CampsAPIClient.getCampById(campId)
+        .then((campResponse) =>
+          campResponse.id ? setCamp(campResponse) : null,
+        )
+        .finally(() =>
+          setIsLoading((prevLoadingState) => {
+            return { ...prevLoadingState, camp: false };
+          }),
+        );
+
+      AdminAPIClient.getWaiver()
+        .then((waiverResponse) =>
+          waiverResponse.clauses ? setWaiver(waiverResponse) : null,
+        )
+        .finally(() =>
+          setIsLoading((prevLoadingState) => {
+            return {
+              ...prevLoadingState,
+              waiver: false,
+            };
+          }),
+        );
+    }
+  }, [campId, registrationResult]);
+
+  if (registrationResult === SUCCESS_RESULT_CODE) {
+    return (
+      <RegistrationResultPage
+        camp={camp}
+        campers={restoredRegistration?.campers}
+        items={
+          restoredRegistration && camp
+            ? mapCampToCartItems(camp, restoredRegistration.campers)
+            : undefined
+        }
+        chargeId={restoredRegistration?.chargeId}
+      />
+    );
+  }
+
+  if (camp && waiver) {
     return sessionSelectionIsComplete ? (
       <RegistrationSteps
-        camp={campResponse}
-        selectedSessions={campResponse.campSessions.filter((session) =>
+        camp={camp}
+        selectedSessions={camp.campSessions.filter((session) =>
           selectedSessions.has(session.id),
         )}
-        waiver={waiverResponse}
+        waiver={waiver}
         onClickBack={() => setSessionSelectionIsComplete(false)}
+        failedCheckoutData={restoredRegistration}
       />
     ) : (
       <SessionSelection
-        camp={campResponse}
+        camp={camp}
         selectedSessions={selectedSessions}
         setSelectedSessions={setSelectedSessions}
         onFormSubmission={() => setSessionSelectionIsComplete(true)}

--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -6,15 +6,13 @@ import AdminAPIClient from "../../../APIClients/AdminAPIClient";
 import CampsAPIClient from "../../../APIClients/CampsAPIClient";
 import { CampResponse } from "../../../types/CampsTypes";
 import { SUCCESS_RESULT_CODE } from "../../../constants/RegistrationConstants";
-import {
-  mapCampToCartItems,
-  restoreRegistrationSessionFromSessionStorage,
-} from "../../../utils/RegistrationUtils";
+import { restoreRegistrationSessionFromSessionStorage } from "../../../utils/RegistrationUtils";
 import { CheckoutData } from "../../../types/RegistrationTypes";
 import RegistrationResultPage from "./RegistrationResult";
 import RegistrationSteps from "./RegistrationSteps";
 import SessionSelection from "./SessionSelection";
 import { Waiver as WaiverType } from "../../../types/AdminTypes";
+import { WaiverInterface } from "../../../types/waiverRegistrationTypes";
 
 type InitialLoadingState = {
   waiver: boolean;
@@ -62,7 +60,7 @@ const RegistrantExperiencePage = (): React.ReactElement => {
         setSelectedSessions(new Set(cachedRegistration.selectedSessionIds));
         setSessionSelectionIsComplete(true);
         setCamp(cachedRegistration.camp);
-        setWaiver(cachedRegistration.waiver);
+        setWaiver(cachedRegistration.waiverInterface.waiver);
       }
     }
 
@@ -96,14 +94,15 @@ const RegistrantExperiencePage = (): React.ReactElement => {
   }, [campId, registrationResult]);
 
   if (registrationResult === SUCCESS_RESULT_CODE) {
+    const sessionsIds = new Set(restoredRegistration?.selectedSessionIds);
+
     return (
       <RegistrationResultPage
         camp={camp}
         campers={restoredRegistration?.campers}
-        items={
-          restoredRegistration && camp
-            ? mapCampToCartItems(camp, restoredRegistration.campers)
-            : undefined
+        sessions={
+          camp?.campSessions.filter((session) => sessionsIds.has(session.id)) ??
+          []
         }
         chargeId={restoredRegistration?.chargeId}
       />

--- a/frontend/src/constants/RegistrationConstants.ts
+++ b/frontend/src/constants/RegistrationConstants.ts
@@ -1,0 +1,5 @@
+export const CAMP_ID_SESSION_STORAGE_KEY = "checkoutSessionCampId";
+
+export const SUCCESS_RESULT_CODE = "success";
+
+export const CANCEL_RESULT_CODE = "cancel";

--- a/frontend/src/constants/RegistrationConstants.ts
+++ b/frontend/src/constants/RegistrationConstants.ts
@@ -3,3 +3,5 @@ export const CAMP_ID_SESSION_STORAGE_KEY = "checkoutSessionCampId";
 export const SUCCESS_RESULT_CODE = "success";
 
 export const CANCEL_RESULT_CODE = "cancel";
+
+export const EDLP_PLACEHOLDER_TIMESLOT = "-";

--- a/frontend/src/types/CamperTypes.ts
+++ b/frontend/src/types/CamperTypes.ts
@@ -42,8 +42,9 @@ export type RegistrantExperienceCamper = Omit<
 // Fields are required by backend
 export type CreateCamperDTO = Omit<
   RegistrantExperienceCamper,
-  "earlyDropoff" | "latePickup" | "optionalClauses"
+  "earlyDropoff" | "latePickup" | "optionalClauses" | "formResponses"
 > & {
+  formResponses?: { [key: string]: string };
   earlyDropoff: string[];
   latePickup: string[];
   optionalClauses: OptionalClause[];

--- a/frontend/src/types/RegistrationTypes.ts
+++ b/frontend/src/types/RegistrationTypes.ts
@@ -1,6 +1,6 @@
-import { Waiver } from "./AdminTypes";
 import { RegistrantExperienceCamper } from "./CamperTypes";
 import { CampResponse } from "./CampsTypes";
+import { WaiverInterface } from "./waiverRegistrationTypes";
 
 export type CartItem = {
   name: string;
@@ -9,24 +9,28 @@ export type CartItem = {
   details?: string;
 };
 
+export type EdlpDetails = {
+  timeSlot: string; // Selected EDLP time
+  units: number; // The units (# of time slots) of the ed (index 0) and lp (index 1) for the selected day per camper
+  cost: number;
+};
+
+export type EdlpChoice = {
+  date: string;
+  earlyDropoff: EdlpDetails;
+  latePickup: EdlpDetails;
+};
+
 // Used for caching data useful for restoring session on failure,
 // or for passing data through checkout flow to display on success
 export type CheckoutData = {
   campers: RegistrantExperienceCamper[];
   camp: CampResponse | undefined;
-  items: CartItem[];
-  waiver: Waiver;
+  waiverInterface: WaiverInterface;
   // Set doesn't work with JSON stringify: https://stackoverflow.com/questions/31190885/json-stringify-a-set
   selectedSessionIds: string[];
   checkoutUrl: string;
   requireEarlyDropOffLatePickup: boolean | null;
+  edlpChoices: EdlpChoice[][];
   chargeId: string;
 };
-
-export enum RegistrationErrors {
-  EmailRecipientsUndefined = "No recipients defined",
-}
-
-export enum RegistrationErrorMessages {
-  Email = "Email validation failed. Please check email and try again.",
-}

--- a/frontend/src/types/RegistrationTypes.ts
+++ b/frontend/src/types/RegistrationTypes.ts
@@ -1,6 +1,32 @@
+import { Waiver } from "./AdminTypes";
+import { RegistrantExperienceCamper } from "./CamperTypes";
+import { CampResponse } from "./CampsTypes";
+
 export type CartItem = {
   name: string;
   campers: number;
   totalPrice: number;
   details?: string;
 };
+
+// Used for caching data useful for restoring session on failure,
+// or for passing data through checkout flow to display on success
+export type CheckoutData = {
+  campers: RegistrantExperienceCamper[];
+  camp: CampResponse | undefined;
+  items: CartItem[];
+  waiver: Waiver;
+  // Set doesn't work with JSON stringify: https://stackoverflow.com/questions/31190885/json-stringify-a-set
+  selectedSessionIds: string[];
+  checkoutUrl: string;
+  requireEarlyDropOffLatePickup: boolean | null;
+  chargeId: string;
+};
+
+export enum RegistrationErrors {
+  EmailRecipientsUndefined = "No recipients defined",
+}
+
+export enum RegistrationErrorMessages {
+  Email = "Email validation failed. Please check email and try again.",
+}

--- a/frontend/src/types/waiverRegistrationTypes.ts
+++ b/frontend/src/types/waiverRegistrationTypes.ts
@@ -1,6 +1,7 @@
 import { Waiver, WaiverClause } from "./AdminTypes";
 
 export type WaiverReducerDispatch =
+  | SetWaiverInterace
   | ClickOptionalClause
   | ClickRequiredClauses
   | FillName
@@ -14,6 +15,11 @@ export interface GetClauses extends WaiverReducerDispatchBase {
 
 export interface WaiverReducerDispatchBase {
   type: WaiverActions;
+}
+
+export interface SetWaiverInterace extends WaiverReducerDispatchBase {
+  type: WaiverActions;
+  waiver: WaiverInterface;
 }
 
 export interface ClickOptionalClause extends WaiverReducerDispatchBase {
@@ -35,6 +41,7 @@ export interface FillDate extends WaiverReducerDispatchBase {
 export interface ClickRequiredClauses extends WaiverReducerDispatchBase {}
 
 export enum WaiverActions {
+  SET_WAIVER_INTERFACE,
   CLICK_OPTIONAL_CLAUSE,
   ClICK_REQUIRED_CLAUSE,
   WRITE_NAME,

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -21,6 +21,7 @@ import {
   Location,
   QuestionType,
 } from "../types/CampsTypes";
+import { EdlpChoice } from "../types/RegistrationTypes";
 
 export const CampStatusColor = {
   [CampStatus.DRAFT]: "yellow",
@@ -296,12 +297,33 @@ export const getMeridianTime = (time: string): string => {
 
 export const mapToCreateCamperDTO = (
   campers: RegistrantExperienceCamper[],
+  edlpChoices: EdlpChoice[][],
 ): CreateCamperDTO[] => {
+  const earlyDropoff = edlpChoices.flatMap((sessionChoices) => {
+    return sessionChoices.reduce((dates: string[], edlpChoice) => {
+      if (edlpChoice.earlyDropoff.timeSlot !== "-") {
+        dates.push(edlpChoice.date.toString());
+      }
+
+      return dates;
+    }, []);
+  });
+
+  const latePickup = edlpChoices.flatMap((sessionChoices) => {
+    return sessionChoices.reduce((dates: string[], edlpChoice) => {
+      if (edlpChoice.latePickup.timeSlot !== "-") {
+        dates.push(edlpChoice.date.toString());
+      }
+
+      return dates;
+    }, []);
+  });
+
   return campers.map((camper) => {
     const camperDTO = {
       ...camper,
-      earlyDropoff: camper.earlyDropoff?.map((date) => date.toString()) ?? [],
-      latePickup: camper.latePickup?.map((date) => date.toString()) ?? [],
+      earlyDropoff,
+      latePickup,
       optionalClauses: camper.optionalClauses ?? [],
     };
 

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -1,6 +1,17 @@
 import { format } from "date-fns";
+import {
+  checkEmail,
+  checkFirstName,
+  checkLastName,
+  checkPhoneNumber,
+  checkRelationToCamper,
+} from "../components/pages/RegistrantExperience/RegistrationSteps/PersonalInfo/personalInfoReducer";
 import MONTHS from "../constants/CampManagementConstants";
 import { BORDER_COLORS, FILL_COLORS } from "../theme/colors";
+import {
+  CreateCamperDTO,
+  RegistrantExperienceCamper,
+} from "../types/CamperTypes";
 import {
   CampResponse,
   CampSession,
@@ -281,4 +292,36 @@ export const getMeridianTime = (time: string): string => {
   const hour = parseInt(hourString, 10);
   const adjustedHour = hour > 12 ? hour - 12 : hour;
   return `${adjustedHour}:${minutesString}${hour < 12 ? "AM" : "PM"}`;
+};
+
+export const mapToCreateCamperDTO = (
+  campers: RegistrantExperienceCamper[],
+): CreateCamperDTO[] => {
+  return campers.map((camper) => {
+    const camperDTO = {
+      ...camper,
+      earlyDropoff: camper.earlyDropoff?.map((date) => date.toString()) ?? [],
+      latePickup: camper.latePickup?.map((date) => date.toString()) ?? [],
+      optionalClauses: camper.optionalClauses ?? [],
+    };
+
+    if (camperDTO.contacts.length === 2) {
+      const [firstContact, secondContact] = camperDTO.contacts;
+      // Remove second contact if empty
+      // TODO show error states if second contact partially filled
+      if (
+        !(
+          checkFirstName(secondContact.firstName) &&
+          checkLastName(secondContact.lastName) &&
+          checkEmail(secondContact.email) &&
+          checkPhoneNumber(secondContact.phoneNumber) &&
+          checkRelationToCamper(secondContact.relationshipToCamper)
+        )
+      ) {
+        camperDTO.contacts = [firstContact];
+      }
+    }
+
+    return camperDTO;
+  });
 };

--- a/frontend/src/utils/RegistrationUtils.ts
+++ b/frontend/src/utils/RegistrationUtils.ts
@@ -1,4 +1,7 @@
-import { CAMP_ID_SESSION_STORAGE_KEY } from "../constants/RegistrationConstants";
+import {
+  CAMP_ID_SESSION_STORAGE_KEY,
+  EDLP_PLACEHOLDER_TIMESLOT,
+} from "../constants/RegistrationConstants";
 import { RegistrantExperienceCamper } from "../types/CamperTypes";
 import { CampResponse, CampSession } from "../types/CampsTypes";
 import { CartItem, CheckoutData, EdlpChoice } from "../types/RegistrationTypes";
@@ -31,7 +34,8 @@ export const mapCampToCartItems = (
 
       if (
         edlpChoices[sessionIndex].some(
-          (edlpChoice) => edlpChoice.earlyDropoff.timeSlot === "-",
+          (edlpChoice) =>
+            edlpChoice.earlyDropoff.timeSlot !== EDLP_PLACEHOLDER_TIMESLOT,
         )
       ) {
         const [cost, units] = edlpChoices[sessionIndex].reduce(
@@ -54,7 +58,8 @@ export const mapCampToCartItems = (
 
       if (
         edlpChoices[sessionIndex].some(
-          (edlpChoice) => edlpChoice.latePickup.timeSlot === "-",
+          (edlpChoice) =>
+            edlpChoice.latePickup.timeSlot !== EDLP_PLACEHOLDER_TIMESLOT,
         )
       ) {
         const [cost, units] = edlpChoices[sessionIndex].reduce(

--- a/frontend/src/utils/RegistrationUtils.ts
+++ b/frontend/src/utils/RegistrationUtils.ts
@@ -1,5 +1,126 @@
-import { CartItem } from "../types/RegistrationTypes";
+import { CAMP_ID_SESSION_STORAGE_KEY } from "../constants/RegistrationConstants";
+import { RegistrantExperienceCamper } from "../types/CamperTypes";
+import { CampResponse } from "../types/CampsTypes";
+import { CartItem, CheckoutData } from "../types/RegistrationTypes";
 
-// eslint-disable-next-line import/prefer-default-export
+export const getCheckoutSessionStorageKey = (campId: string): string =>
+  `checkout-${campId}`;
+
+export const mapCampToCartItems = (
+  camp: CampResponse,
+  campers: RegistrantExperienceCamper[],
+): CartItem[] => {
+  const items: CartItem[] = [
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+      details: "Some sample details",
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+    {
+      name: "yes",
+      campers: 2,
+      totalPrice: 15.5,
+    },
+  ];
+
+  return items;
+};
+
 export const calculateTotalPrice = (cartItems: CartItem[]): number =>
   cartItems.reduce((prevTotal, curItem) => prevTotal + curItem.totalPrice, 0);
+
+// `formResponses` is a Map, which does not stringify easily
+// https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map
+type JSONRegistrantExperienceCamper = Omit<
+  RegistrantExperienceCamper,
+  "formResponses"
+> & {
+  formResponses?: [string, string][];
+};
+
+export const saveRegistrationSessionToSessionStorage = (
+  sessionCampId: string, // better named `campId`, but linter doesn't like
+  checkoutData: CheckoutData,
+): void => {
+  const parseData: Omit<CheckoutData, "campers"> & {
+    campers: Array<JSONRegistrantExperienceCamper>;
+  } = {
+    ...checkoutData,
+    campers: checkoutData.campers.map((camper) => {
+      return {
+        ...camper,
+        formResponses: camper.formResponses
+          ? Array.from(camper.formResponses.entries())
+          : undefined,
+      };
+    }),
+  };
+
+  sessionStorage.setItem(CAMP_ID_SESSION_STORAGE_KEY, sessionCampId);
+  sessionStorage.setItem(
+    getCheckoutSessionStorageKey(sessionCampId),
+    JSON.stringify(parseData),
+  );
+};
+
+export const restoreRegistrationSessionFromSessionStorage = ():
+  | CheckoutData
+  | undefined => {
+  try {
+    let restoredSession: CheckoutData | undefined;
+    const checkoutCampId = sessionStorage.getItem(CAMP_ID_SESSION_STORAGE_KEY);
+
+    if (checkoutCampId) {
+      const checkoutKey = getCheckoutSessionStorageKey(checkoutCampId);
+      const sessionData = sessionStorage.getItem(checkoutKey);
+
+      if (sessionData) {
+        const parsedSession = JSON.parse(sessionData);
+        restoredSession = {
+          ...parsedSession,
+          campers: parsedSession.campers.map(
+            (camper: JSONRegistrantExperienceCamper) => {
+              return {
+                ...camper,
+                formResponses: camper.formResponses
+                  ? new Map(camper.formResponses)
+                  : undefined,
+              };
+            },
+          ),
+        };
+      }
+      sessionStorage.clear();
+    }
+
+    return restoredSession;
+  } catch (err: unknown) {
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Registrant Experience: Payment Failure/Confirmation](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=c4a45ddbdb1f433cbf01448ede701316&pm=c)
[Payments - Stripe API](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=5758698f7e8d440da53b92b84082df3c&pm=c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Used session storage to cache session details and restore session when the user clicks "back"
  * `sessionStorage` is different from `localStorage`, expires: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage 
* Creates a bunch of components for result handling in `RegistrationResult/`

Based on work in https://github.com/uwblueprint/focus-on-nature/pull/117:
* To get around CORS errors for redirect, let's return the created checkout link and then initiate the movement to the stripe page in the frontend
* Tried adding this to the CORS allowlist but it wasn't enough, I suspect it's bc we can't control the Stripe origin?
* Also adds default camp image


The full e2e flow looks like:
* User goes through registration flow, clicks register
* Request sent to backend to create campers in db, and create checkout session in Stripe
  * If success, return the checkout session URL
  * If failed, return to checkout and show the checkout error modal
* Save session data (see `CheckoutData`) to session storage, including checkout URL, and redirect to checkout
  * note: handling for pressing back on webpage isn't great, is it worth using `window.location.replace()` instead of `window.location.assign()`?
* Stripe checkout
  * If payment success, Stripe redirects to `/register/camp/:campId?result=success`. We retrieve session storage for this page to load summary; if this fails, we have a generic message that says check email
  * If payment fails, Stripe handles that in the webpage (no redirect)
  * If payment cancelled (pressed back arrow on the Stripe checkout page), Stripe redirects to `/register/camp/:campId?result=cancel`. We restore session details from session storage and show error modal.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go through all checkout/payment flows using a Stripe test card (https://stripe.com/docs/testing)
  a. cancel (press back button) 
  b. complete payment -> should end up at success page
  c. incorrect card details / payment decline (see Stripe docs)
2. Look for success page states: through Stripe payment, also access directly and look at error state
3. Check mobile states for all of above (I think the modal is too wide on phone?)
4. Mess around with session Storage (invalidate it manually, see if app handles it)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Look at `frontend/` only please -- backend created in separate PR https://github.com/uwblueprint/focus-on-nature/pull/212, and will rebase later


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
