### PR TITLE
fix: Form Responses empty object bug in Registrant Experience

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/QuestionCards/CamperQuestionsCard.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/AdditionalInfo/QuestionCards/CamperQuestionsCard.tsx
@@ -31,7 +31,7 @@ const CamperQuestionsCard = ({
         <Wrap width="100%" px="20px" justify="space-between">
           {campSpecificFormQuestions.map((question) => (
             <WrapItem
-              key={`additional_info_question_${question}`}
+              key={`additional_info_question_${question.id}`}
               width={{ sm: "100%", md: mdWrapWidth }}
               px="20px"
               py="12px"

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/PersonalInfo/personalInfoReducer.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/PersonalInfo/personalInfoReducer.tsx
@@ -19,6 +19,11 @@ export const CamperReducer = (
     const newCampers: RegistrantExperienceCamper[] = JSON.parse(
       JSON.stringify(campers),
     ); // Deep Copy
+
+    for (let i = 0; i < campers.length; i += 1) {
+      newCampers[i].formResponses = campers[i].formResponses;
+    } // Copy the formResponses map
+
     switch (action.type) {
       case PersonalInfoActions.ADD_CAMPER: {
         newCampers.push({
@@ -32,7 +37,7 @@ export const CamperReducer = (
           optionalClauses: [],
         });
 
-        // inject contact info
+        // Inject contact info
         newCampers[0].contacts.forEach((contact) => {
           newCampers[newCampers.length - 1].contacts.push(
             JSON.parse(JSON.stringify(contact)),


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Registrant Experience: Camper formQuestions become empty objects from maps](https://www.notion.so/uwblueprintexecs/Registrant-Experience-Camper-formQuestions-become-empty-objects-from-maps-2f7fb75e14a04c189396be841b6ba019)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The problem was that in making a deep copy (check changed files), the JSON.stringify/parse methods would convert the formResponses maps into empty objects since maps aren't serializable, and then using the .get method on the empty objects would fail (since they're only supposed to work on maps).
* To fix this, I added a for loop to copy over the maps from `Campers` after the `newCampers` array is made.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Register for any camp i.e. http://localhost:3000/register/camp/63139c7bc3d7b55b44a01531
2. Fill out step 1
3. Fill out step 2
4. Go back to step 1 and try to update the camper information, if it doesn't crash it works (currently this causes it to crash due to the problem above).

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
