### PR TITLE
Fix: Safari time picker

### DIFF
--- a/frontend/src/components/common/TimePicker.tsx
+++ b/frontend/src/components/common/TimePicker.tsx
@@ -1,0 +1,39 @@
+import { Flex } from "@chakra-ui/react";
+import React from "react";
+
+type TimePickerProps = {
+  isShowingErrors: boolean;
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+// The <Input> element from Chakra did not work in Safari
+const TimePicker = ({
+  isShowingErrors,
+  value,
+  onChange,
+}: TimePickerProps): React.ReactElement => {
+  return (
+    <Flex
+      direction="row"
+      align="center"
+      borderColor={isShowingErrors ? "red" : "gray.200"}
+      borderWidth={isShowingErrors ? "2px" : "1px"}
+      borderRadius="6px"
+      width="160px"
+      height="52px"
+      px={4}
+    >
+      <input
+        type="time"
+        placeholder="XX:XX"
+        color="transparent"
+        style={{ backgroundColor: "inherit", width: "100%" }}
+        value={value}
+        onChange={onChange}
+      />
+    </Flex>
+  );
+};
+
+export default TimePicker;

--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 import IconImage from "../../../../assets/icon_image.svg";
 import { MAX_CAMP_DESC_LENGTH } from "../../../../constants/CampManagementConstants";
+import TimePicker from "../../../common/TimePicker";
 
 type CampCreationDetailsProps = {
   campName: string;
@@ -215,50 +216,37 @@ const CampCreationDetails = ({
       {errorText(dailyCampFee, "You must add a fee.")}
 
       <HStack alignItems="start" spacing={4} marginTop="24px">
-        <Box width="160px">
+        <VStack spacing={2} align="flex-start">
           <Text textStyle="buttonSemiBold">
             Start Time{" "}
             <Text as="span" textStyle="buttonSemiBold" color="red">
               *
             </Text>
           </Text>
-
-          <Input
-            type="time"
-            placeholder="XX:XX"
-            width="160px"
-            height="52px"
-            marginTop="8px"
-            defaultValue={startTime}
-            borderColor={!startTime && showErrors ? "red" : "gray.200"}
-            borderWidth={!startTime && showErrors ? "2px" : "1px"}
+          <TimePicker
+            isShowingErrors={!startTime && showErrors}
+            value={startTime}
             onChange={handleStartTime}
           />
           {errorText(startTime, "You must specify a time.")}
-        </Box>
+        </VStack>
 
         <Text paddingTop="45px"> to </Text>
 
-        <Box width="160px">
+        <VStack width="160px" spacing={2} align="flex-start">
           <Text textStyle="buttonSemiBold">
             End Time{" "}
             <Text as="span" textStyle="buttonSemiBold" color="red">
               *
             </Text>
           </Text>
-          <Input
-            type="time"
-            placeholder="XX:XX"
-            width="160px"
-            height="52px"
-            marginTop="8px"
-            defaultValue={endTime}
-            borderColor={!endTime && showErrors ? "red" : "gray.200"}
-            borderWidth={!endTime && showErrors ? "2px" : "1px"}
+          <TimePicker
+            isShowingErrors={!endTime && showErrors}
+            value={endTime}
             onChange={handleEndTime}
           />
           {errorText(endTime, "You must specify a time.")}
-        </Box>
+        </VStack>
       </HStack>
 
       <HStack
@@ -341,55 +329,37 @@ const CampCreationDetails = ({
       {offersEDLP && (
         <Box>
           <HStack alignItems="start" spacing={4} marginTop="24px">
-            <Box width="160px">
+            <VStack width="160px" spacing={2} align="flex-start">
               <Text textStyle="buttonSemiBold">
                 Earliest Drop-off{" "}
                 <Text as="span" textStyle="buttonSemiBold" color="red">
                   *
                 </Text>
               </Text>
-
-              <Input
-                type="time"
-                placeholder="XX:XX"
-                width="160px"
-                height="52px"
-                marginTop="8px"
-                defaultValue={earliestDropOffTime}
-                borderColor={
-                  !earliestDropOffTime && showErrors ? "red" : "gray.200"
-                }
-                borderWidth={!earliestDropOffTime && showErrors ? "2px" : "1px"}
+              <TimePicker
+                isShowingErrors={!earliestDropOffTime && showErrors}
+                value={earliestDropOffTime}
                 onChange={handleEarliestDropOffTime}
               />
               {errorText(earliestDropOffTime, "You must specify a time.")}
-            </Box>
+            </VStack>
 
             <Text paddingTop="45px"> to </Text>
 
-            <Box width="160px">
+            <VStack width="160px" spacing={2} align="flex-start">
               <Text textStyle="buttonSemiBold">
                 Latest Pick-up{" "}
                 <Text as="span" textStyle="buttonSemiBold" color="red">
                   *
                 </Text>
               </Text>
-
-              <Input
-                type="time"
-                placeholder="XX:XX"
-                width="160px"
-                height="52px"
-                marginTop="8px"
-                defaultValue={latestPickUpTime}
-                borderColor={
-                  !latestPickUpTime && showErrors ? "red" : "gray.200"
-                }
-                borderWidth={!latestPickUpTime && showErrors ? "2px" : "1px"}
+              <TimePicker
+                isShowingErrors={!latestPickUpTime && showErrors}
+                value={latestPickUpTime}
                 onChange={handleLatestPickUpTime}
               />
               {errorText(latestPickUpTime, "You must specify a time.")}
-            </Box>
+            </VStack>
           </HStack>
 
           <Text textStyle="buttonSemiBold" marginTop="24px">

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -389,8 +389,8 @@ const CampCreationPage = (): React.ReactElement => {
                 event: React.ChangeEvent<HTMLInputElement>,
               ) => setCampCapacity(Number(event.target.value))}
               toggleEDLP={(event: React.ChangeEvent<HTMLInputElement>) => {
-                // If currently offers EDLP, reset the state of the timings to default values
-                if (offersEDLP) {
+                // When EDLP reset, change timings to default values
+                if (!offersEDLP) {
                   setEarliestDropOffTime("");
                   setLatestPickUpTime("");
                   setPriceEDLP(0);


### PR DESCRIPTION

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Creation: Unable to progress through camp creation flow on Safari](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=711f3a0f1a1a4c2cb878f2496bbf3017&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* TL;DR the Safari validation was failing, it's because the `<Input>` element in Chakra doesn't work on Safari. Created a custom equivalent
* Changed one piece of logic where we want to clear values of EDLP, in case the user checks EDLP then creates values, then  unchecks EDLP -- want to make sure these values are not sent in the "create camp" call


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Please test on other browsers


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
