### PR TITLE
fix: require province to proceed

### DIFF
--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -73,8 +73,7 @@ const CampCreationPage = (): React.ReactElement => {
     campCapacity &&
     addressLine1 &&
     city &&
-    province &&
-    province &&
+    province !== "-" &&
     postalCode
   )
     isCampDetailsFilled = true;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Creation: Camp is allowed to be made without selecting a province](https://www.notion.so/uwblueprintexecs/Task-Board-F22-9e03bf9f7c4343f09a8a5c16dc48a12a?p=a7e4d0a522a94a338f30c7794143e72b&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
