### PR TITLE
fix: modals await network requests

### DIFF
--- a/frontend/src/components/common/DeleteModal.tsx
+++ b/frontend/src/components/common/DeleteModal.tsx
@@ -50,7 +50,13 @@ const DeleteModal = ({
             <Button mr={3} onClick={onClose}>
               <Text>Cancel</Text>
             </Button>
-            <Button colorScheme="red" onClick={onDelete}>
+            <Button
+              colorScheme="red"
+              onClick={() => {
+                onClose();
+                onDelete();
+              }}
+            >
               {buttonLabel}
             </Button>
           </HStack>

--- a/frontend/src/components/pages/AccessControl/index.tsx
+++ b/frontend/src/components/pages/AccessControl/index.tsx
@@ -182,7 +182,6 @@ const AccessControlPage = (): JSX.Element => {
         duration: 3000,
       });
     }
-    onClose();
     setUserToChangeStatus(null);
   };
 
@@ -217,9 +216,13 @@ const AccessControlPage = (): JSX.Element => {
         buttonColor={userToChangeStatus?.active ? "red" : "green"}
         isOpen={isOpen}
         onClose={onClose}
-        onChangeStatus={() =>
-          userToChangeStatus && handleStatusChange(userToChangeStatus)
-        }
+        onChangeStatus={() => {
+          if (userToChangeStatus) {
+            handleStatusChange(userToChangeStatus);
+          }
+
+          onClose();
+        }}
       />
       <Text mb="35px" textStyle="displayXLarge">
         FON Staff Access Control

--- a/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
@@ -108,7 +108,6 @@ const WaitlistedCampersTable = ({
         waitlistedCamper.id,
       );
 
-      onClose();
       if (deletedWaitlistedCamperResponse) {
         toast({
           description: `${camperToDeleteName} has been removed from the waitlist for this camp session.`,

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -71,7 +71,6 @@ const CampsListPage = (): React.ReactElement => {
         duration: 3000,
       });
     }
-    onDeleteModalClose();
     setCampToDelete(null);
   };
 
@@ -89,7 +88,7 @@ const CampsListPage = (): React.ReactElement => {
         buttonLabel="Remove"
         isOpen={isDeleteModalOpen}
         onClose={onDeleteModalClose}
-        onDelete={() => handleConfirmDelete()}
+        onDelete={handleConfirmDelete}
       />
       <Flex
         width={isDrawerOpen ? "calc(100% - 500px)" : "100%"}

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/PersonalInfo/CamperCard.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/PersonalInfo/CamperCard.tsx
@@ -136,7 +136,6 @@ const CamperCard = ({
           isClosable: false,
           variant: "subtle",
         });
-        onClose();
       },
     });
 


### PR DESCRIPTION
Think we're running into the problem that the user can submit multiple mutations since the UI hangs while waiting for a network response (without telling the user what's happening). We can either show a loading state or just close the modal and rely on the toasts to deliver the result. The first one has the advantage that it's easier to re-do an action, but if we're confident in actions succeeding more often than not, I think the second is a smoother experience. 

Thoughts?

[Still a WIP, there's probably other blocking UI examples in the repo]

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
