### PR TITLE
Fix: Call Remove waitlisted camper only once

### DIFF
--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -45,7 +45,10 @@ const CampersTables = ({
             />
           </TabPanel>
           <TabPanel padding="0">
-            <WaitlistedCampersTable waitlistedCampers={campSession.waitlist} />
+            <WaitlistedCampersTable
+              waitlistedCampers={campSession.waitlist}
+              handleRefetch={handleRefetch}
+            />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
@@ -37,10 +37,12 @@ import DeleteModal from "../../../common/DeleteModal";
 
 type WaitlistedCampersTableProps = {
   waitlistedCampers: WaitlistedCamper[];
+  handleRefetch: () => void;
 };
 
 const WaitlistedCampersTable = ({
   waitlistedCampers,
+  handleRefetch,
 }: WaitlistedCampersTableProps): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [
@@ -103,12 +105,12 @@ const WaitlistedCampersTable = ({
   const confirmDeleteWaitlistedCamper = async (
     waitlistedCamper: WaitlistedCamper | null,
   ) => {
+    onClose();
     if (waitlistedCamper) {
       const deletedWaitlistedCamperResponse = await CamperAPIClient.deleteWaitlistedCamperById(
         waitlistedCamper.id,
       );
 
-      onClose();
       if (deletedWaitlistedCamperResponse) {
         toast({
           description: `${camperToDeleteName} has been removed from the waitlist for this camp session.`,
@@ -124,6 +126,7 @@ const WaitlistedCampersTable = ({
           duration: 3000,
         });
       }
+      handleRefetch();
     }
   };
 

--- a/frontend/src/components/pages/CampsList/index.tsx
+++ b/frontend/src/components/pages/CampsList/index.tsx
@@ -49,7 +49,7 @@ const CampsListPage = (): React.ReactElement => {
     if (!campToDelete) {
       return;
     }
-
+    onDeleteModalClose();
     const res = await CampsAPIClient.deleteCamp(campToDelete.id);
     if (res) {
       toast({
@@ -71,7 +71,6 @@ const CampsListPage = (): React.ReactElement => {
         duration: 3000,
       });
     }
-    onDeleteModalClose();
     setCampToDelete(null);
   };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Disable remove CTA/ close modal when the backend is processing the remove waitlisted camper CTA + reload the page on success](https://www.notion.so/uwblueprintexecs/Camp-Overview-Disable-remove-CTA-close-modal-when-the-backend-is-processing-the-remove-waitlisted--dbc73a5e64fc4e51bd2733f47e7b5fa3)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Moved the onClose so that the modal closes before the backend call.
* Added our good ol' handle refetch so that it refetches (refreshes) the page right after the call.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to http://localhost:3000/admin/camp/6397f94e2ff11dcda0ba4960, or any other camp with someone on a waitlist (or add a camper to the waitlist, you'll have to do this manually right now through mongo or postman).
2. Try to remove a camper from the waitlist and spam click the remove button.
3. Make sure only one backend call is made and that the page refreshes right after.


https://user-images.githubusercontent.com/30396273/213935842-fb63a135-4c7a-4190-bceb-2020494a12f2.mp4


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, functionality.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
