### PR TITLE
Fix: Render dates correctly

### DIFF
--- a/frontend/src/components/common/camps/CampSessionInfoHeader.tsx
+++ b/frontend/src/components/common/camps/CampSessionInfoHeader.tsx
@@ -73,6 +73,7 @@ const CampSessionInfoHeader = ({
           campSession.dates,
           camp.startTime,
           camp.endTime,
+          true,
         )}
       </Text>
       <Box marginTop="16px">

--- a/frontend/src/components/pages/CampOverview/ManageSessions/ManageSessionsModalTable.tsx
+++ b/frontend/src/components/pages/CampOverview/ManageSessions/ManageSessionsModalTable.tsx
@@ -108,6 +108,7 @@ const ManageSessionsModalTable = ({
                       session.dates,
                       campStartTime,
                       campEndTime,
+                      true,
                     )}
                   </Text>
                 </Td>

--- a/frontend/src/components/pages/CampsList/CampsTable.tsx
+++ b/frontend/src/components/pages/CampsList/CampsTable.tsx
@@ -1,5 +1,4 @@
 import React, { Dispatch, SetStateAction } from "react";
-
 import { useHistory } from "react-router-dom";
 import { SearchIcon } from "@chakra-ui/icons";
 import { FaEllipsisV } from "react-icons/fa";
@@ -195,10 +194,7 @@ const CampsTable = ({
                 }}
               >
                 {camp.campSessions.length > 0
-                  ? getFormattedCampDateRange(
-                      camp.campSessions[0].dates,
-                      camp.campSessions[camp.campSessions.length - 1].dates,
-                    )
+                  ? getFormattedCampDateRange(camp.campSessions)
                   : ""}
               </Td>
               <Td

--- a/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
+++ b/frontend/src/components/pages/CampsList/PreviewModalSessionRow.tsx
@@ -38,7 +38,7 @@ const PreviewModalSessionRow = ({
         </>
       </Flex>
       <Text textStyle="subHeading">
-        {getFormattedDateString(session.dates)}
+        {getFormattedDateString(session.dates, true)}
       </Text>
       <Text textStyle="caption">
         Registrations (

--- a/frontend/src/components/pages/RegistrantExperience/SessionSelection/SessionCard.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/SessionSelection/SessionCard.tsx
@@ -7,7 +7,7 @@ import {
   sessionCardDatesTextStyles,
   sessionCardDetailsTextStyles,
 } from "./SessionSelectionStyles";
-import { getMeridianTime } from "../../../../utils/CampUtils";
+import { getMeridianTime, sortDateStrings } from "../../../../utils/CampUtils";
 
 const WAITLISTED_COLOR = "red.100";
 const AVAILABLE_COLOR = "green.100";
@@ -27,13 +27,14 @@ const SessionCardDetails = ({
   campSession,
 }: SessionCardDetailsProps): React.ReactElement => {
   const getCampSessionDates = () => {
-    const startDate = new Date(campSession.dates[0]);
-    const endDate = new Date(campSession.dates[campSession.dates.length - 1]);
+    const datesToUse = sortDateStrings(campSession.dates);
+    const startDate = new Date(datesToUse[0]);
+    const endDate = new Date(datesToUse[campSession.dates.length - 1]);
     return `${startDate.toLocaleString("default", {
       month: "short",
-    })} ${startDate.getDay()} - ${endDate.toLocaleString("default", {
+    })} ${startDate.getDate()} - ${endDate.toLocaleString("default", {
       month: "short",
-    })} ${endDate.getDay()}, ${endDate.getFullYear()}`;
+    })} ${endDate.getDate()}, ${endDate.getFullYear()}`;
   };
 
   const formattedTimeString = (start: string, end: string): string => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Registrant Experience] Dates to select session are incorrect](https://www.notion.so/uwblueprintexecs/Registrant-Experience-Dates-to-select-session-are-incorrect-ee341f9de21d421eb8be0bc903ea4843)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* This ticket accounts for all problems in rendering dates
* The biggest issue that I encountered in a lot of places is that we do not sort the dates. The dates in the order which they appear in an object are not sorted, so simply taking the first and last elements in the dates array is not sufficient, that's why we display strange date strings (shown below).


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate around the entire site (literally everything) and ensure all dates make sense- they should comply with the actual info of the camp object, and the order should also be correct. Let me know if I missed anything. Here are the 5 places where I made changes:

**Before:**
![image](https://user-images.githubusercontent.com/30396273/213984528-bbd615a0-f878-42fc-9699-09ee03d07e77.png)
![image](https://user-images.githubusercontent.com/30396273/213984550-8d00c2f4-4f97-41c2-8109-8477b41f2fe4.png)
![image](https://user-images.githubusercontent.com/30396273/213984616-8501f052-b593-4a99-a5ee-25b39dd12357.png)
![image](https://user-images.githubusercontent.com/30396273/213984664-48c44a66-fb3a-46d1-909e-456c22739330.png)
![image](https://user-images.githubusercontent.com/30396273/213984799-d9cd4c31-db6e-409b-b67a-100c88b03be8.png)

**After:**
![image](https://user-images.githubusercontent.com/30396273/213984872-4e745699-7f7f-47b1-97d6-f2764cf03e79.png)
![image](https://user-images.githubusercontent.com/30396273/213984907-b98225b3-f49d-468d-95a4-131805e6e7a7.png)
![image](https://user-images.githubusercontent.com/30396273/213984988-19517a1a-66e6-4182-b7c4-e2bb43a30afc.png)
![image](https://user-images.githubusercontent.com/30396273/213985014-9e282cdd-ee05-4dcf-97a5-d222ded75a60.png)
![image](https://user-images.githubusercontent.com/30396273/213985063-d0555005-c155-4cdc-b26d-0500719c2975.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, and also make sure I covered every case of incorrect date strings.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
