### PR TITLE
Fix: Display EDLP tag applicable to a session

### DIFF
--- a/frontend/src/components/pages/CampOverview/CampersTable/CamperDetailsBadge.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CamperDetailsBadge.tsx
@@ -15,16 +15,19 @@ import { ReactComponent as SunriseIcon } from "../../../../assets/icon_sunrise.s
 import { ReactComponent as SunsetIcon } from "../../../../assets/icon_sunset.svg";
 
 import { Camper, WaitlistedCamperStatus } from "../../../../types/CamperTypes";
+import { checkDatesInRange } from "../../../../utils/CampUtils";
+
+type CamperDetailsBadgeProps = {
+  icon: JSX.Element;
+  description: string;
+  color: string;
+};
 
 const CamperDetailsBadge = ({
   icon,
   description,
   color,
-}: {
-  icon: JSX.Element;
-  description: string;
-  color: string;
-}): JSX.Element => {
+}: CamperDetailsBadgeProps): JSX.Element => {
   return (
     <HStack
       alignContent="center"
@@ -39,15 +42,33 @@ const CamperDetailsBadge = ({
   );
 };
 
+type CamperDetailsBadgeGroupProps = {
+  camper: Camper;
+  paddingLeft?: string;
+  sessionDates: string[];
+};
+
 export const CamperDetailsBadgeGroup = ({
   camper,
   paddingLeft = "16px",
-}: {
-  camper: Camper;
-  paddingLeft?: string;
-}): JSX.Element => {
-  const latePickup = camper.latePickup && camper.latePickup.length > 0;
-  const earlyDropoff = camper.earlyDropoff && camper.earlyDropoff.length > 0;
+  sessionDates,
+}: CamperDetailsBadgeGroupProps): JSX.Element => {
+  const latePickupInSessionRange = checkDatesInRange(
+    sessionDates,
+    camper.latePickup,
+  );
+  const earlyDropoffInSessionRange = checkDatesInRange(
+    sessionDates,
+    camper.earlyDropoff,
+  );
+  const latePickup =
+    camper.latePickup &&
+    camper.latePickup.length > 0 &&
+    latePickupInSessionRange;
+  const earlyDropoff =
+    camper.earlyDropoff &&
+    camper.earlyDropoff.length > 0 &&
+    earlyDropoffInSessionRange;
 
   return (
     <Container width="-webkit-fit-content" marginStart="0px" pl={paddingLeft}>

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTable.tsx
@@ -61,19 +61,23 @@ const ExportButton = ({
   );
 };
 
+type CampersTableProps = {
+  campers: Camper[];
+  campSessionCapacity: number;
+  formQuestions: FormQuestion[];
+  handleRefetch: () => void;
+  generateCsv: () => void;
+  sessionDates: string[];
+};
+
 const CampersTable = ({
   campers,
   campSessionCapacity,
   formQuestions,
   handleRefetch,
   generateCsv,
-}: {
-  campers: Camper[];
-  campSessionCapacity: number;
-  formQuestions: FormQuestion[];
-  handleRefetch: () => void;
-  generateCsv: () => void;
-}): JSX.Element => {
+  sessionDates,
+}: CampersTableProps): JSX.Element => {
   const [search, setSearch] = React.useState("");
   const [selectedFilter, setSelectedFilter] = React.useState<Filter>(
     Filter.ALL,
@@ -256,7 +260,10 @@ const CampersTable = ({
                     )}
                   </Td>
                   <Td pl="7px" maxWidth="760px">
-                    <CamperDetailsBadgeGroup camper={camper} />
+                    <CamperDetailsBadgeGroup
+                      camper={camper}
+                      sessionDates={sessionDates}
+                    />
                   </Td>
                   <Td
                     justifyContent="flex-end"
@@ -302,6 +309,7 @@ const CampersTable = ({
               camper={selectedCamper}
               viewCamperModalIsOpen={viewModalIsOpen}
               viewCamperOnClose={viewModalOnClose}
+              sessionDates={sessionDates}
             />
           )}
 

--- a/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/CampersTables.tsx
@@ -42,6 +42,7 @@ const CampersTables = ({
               campSessionCapacity={campSession.capacity}
               handleRefetch={handleRefetch}
               generateCsv={generateCsv}
+              sessionDates={campSession.dates}
             />
           </TabPanel>
           <TabPanel padding="0">

--- a/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
@@ -4,7 +4,6 @@ import {
   ModalOverlay,
   ModalContent,
   ModalHeader,
-  ModalCloseButton,
   Modal,
   ModalBody,
   ModalFooter,
@@ -131,7 +130,6 @@ const EditCamperModal = ({
         <ModalHeader>
           Edit {camper.firstName} {camper.lastName}&apos;s Information
         </ModalHeader>
-        <ModalCloseButton />
         <ModalBody overflowY="scroll">
           <EditCamperModalForm
             formQuestions={formQuestions}

--- a/frontend/src/components/pages/CampOverview/ViewCamperModal/PickupDropoffTableRow.tsx
+++ b/frontend/src/components/pages/CampOverview/ViewCamperModal/PickupDropoffTableRow.tsx
@@ -54,7 +54,7 @@ const PickupDropoffTime = ({
   return (
     <Td pl={0} pt={2} pb={0} color={color}>
       <HStack>
-        {pickup ? <SunsetIcon fill={color} /> : <SunriseIcon fill={color} />}
+        {pickup ? <SunriseIcon fill={color} /> : <SunsetIcon fill={color} />}
         <Text textStyle="bodyRegular" color={color}>
           {time}
         </Text>

--- a/frontend/src/components/pages/CampOverview/ViewCamperModal/PickupDropoffTableRow.tsx
+++ b/frontend/src/components/pages/CampOverview/ViewCamperModal/PickupDropoffTableRow.tsx
@@ -54,7 +54,7 @@ const PickupDropoffTime = ({
   return (
     <Td pl={0} pt={2} pb={0} color={color}>
       <HStack>
-        {pickup ? <SunriseIcon fill={color} /> : <SunsetIcon fill={color} />}
+        {pickup ? <SunsetIcon fill={color} /> : <SunriseIcon fill={color} />}
         <Text textStyle="bodyRegular" color={color}>
           {time}
         </Text>

--- a/frontend/src/components/pages/CampOverview/ViewCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/ViewCamperModal/index.tsx
@@ -21,12 +21,14 @@ type ViewCamperModalProps = {
   viewCamperModalIsOpen: boolean;
   viewCamperOnClose: () => void;
   camper: Camper;
+  sessionDates: string[];
 };
 
 const ViewCamperModal = ({
   viewCamperModalIsOpen,
   viewCamperOnClose,
   camper,
+  sessionDates,
 }: ViewCamperModalProps): JSX.Element => {
   return (
     <Modal
@@ -60,7 +62,11 @@ const ViewCamperModal = ({
               (prevTotal, curCharge) => prevTotal + curCharge,
             )}
           </Text>
-          <CamperDetailsBadgeGroup camper={camper} paddingLeft="0px" />
+          <CamperDetailsBadgeGroup
+            camper={camper}
+            paddingLeft="0px"
+            sessionDates={sessionDates}
+          />
         </ModalHeader>
 
         <ModalBody pl={8} pr={8} pb={0} pt={0}>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/RegistrationFooter.tsx
@@ -71,6 +71,7 @@ const RegistrationFooter = ({
       <Button
         ref={nextBtnRef}
         width={{ sm: "95vw", md: "45vw", lg: "auto" }}
+        mr={{ sm: 0, lg: 4 }}
         height="48px"
         variant="primary"
         isLoading={registrationLoading}

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
@@ -409,7 +409,6 @@ const RegistrationSteps = ({
   return (
     <Flex
       direction="column"
-      w="100vw"
       pt={{ sm: "120px", md: "120px", lg: "144px" }}
       pb={{ sm: "170px", md: "108px", lg: "144px" }}
       justifyContent="flex-start"

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -490,19 +490,12 @@ export const checkDatesInRange = (
 ): boolean => {
   if (!datesToCheck || datesToCheck.length === 0) return false;
 
-  let minDate = Number.MAX_VALUE;
-  let maxDate = Number.MIN_VALUE;
+  const minDate = Math.min(...rangeDates.map((date) => Date.parse(date)));
+  const maxDate = Math.max(...rangeDates.map((date) => Date.parse(date)));
 
-  rangeDates.forEach((dateStr: string) => {
-    minDate = Math.min(Date.parse(dateStr), minDate);
-    maxDate = Math.max(Date.parse(dateStr), maxDate);
-  });
-
-  let result = false;
-  datesToCheck.forEach((date: Date) => {
-    const curDate = new Date(date);
-    const dateNum = curDate.getTime();
-    if (dateNum >= minDate && dateNum <= maxDate) result = true;
-  });
-  return result;
+  return datesToCheck.some(
+    (date: Date) =>
+      new Date(date).getTime() >= minDate &&
+      new Date(date).getTime() <= maxDate,
+  );
 };

--- a/frontend/src/utils/CampUtils.ts
+++ b/frontend/src/utils/CampUtils.ts
@@ -483,3 +483,26 @@ export const getFormattedCampDateRange = (camp: CampResponse): string => {
     ? `${format(firstCampDate, "PP")} - ${format(lastCampDate, "PP")}`
     : "";
 };
+
+export const checkDatesInRange = (
+  rangeDates: string[],
+  datesToCheck?: Date[],
+): boolean => {
+  if (!datesToCheck || datesToCheck.length === 0) return false;
+
+  let minDate = Number.MAX_VALUE;
+  let maxDate = Number.MIN_VALUE;
+
+  rangeDates.forEach((dateStr: string) => {
+    minDate = Math.min(Date.parse(dateStr), minDate);
+    maxDate = Math.max(Date.parse(dateStr), maxDate);
+  });
+
+  let result = false;
+  datesToCheck.forEach((date: Date) => {
+    const curDate = new Date(date);
+    const dateNum = curDate.getTime();
+    if (dateNum >= minDate && dateNum <= maxDate) result = true;
+  });
+  return result;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Registrant Experience] Dates to select session are incorrect](https://www.notion.so/uwblueprintexecs/Registrant-Experience-Dates-to-select-session-are-incorrect-ee341f9de21d421eb8be0bc903ea4843)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Passed in a particular session as a prop
* Using the session's dates, I can conditionally render the EDLP tags if the camper's selected EDLP dates are within the particular session's range


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/admin/camp/6396319f01dd5e987a03b516
2. Ensure that the campers that have EDLP only display the purple EDLP tags if the EDLP date is in range.

**Before:**
![image](https://user-images.githubusercontent.com/30396273/214161667-5978aead-b9e0-4f59-8859-7a3a30f3c082.png)

**After:**
![image](https://user-images.githubusercontent.com/30396273/214161725-bc0db65f-8e0d-4e66-b988-a51626e82578.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, functionality.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
