### PR TITLE
Fix camper edit functionality

### DIFF
--- a/backend/typescript/middlewares/validators/adminValidators.ts
+++ b/backend/typescript/middlewares/validators/adminValidators.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { validateFormQuestion } from "./formQuestionValidators";
 import { validatePrimitive, getApiValidationError } from "./util";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const validateClause = (clause: any): boolean => {
   if (!validatePrimitive(clause.text, "string")) {
     return false;

--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -210,8 +210,8 @@ export const createUpdateCampDtoValidator = async (
       const campSession = body.campSessions[i];
       try {
         createCampSessionDTOValidator(campSession);
-      } catch (err: any) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (err: any) {
         res.status(400).send(err.message);
       }
     }

--- a/backend/typescript/middlewares/validators/camperValidators.ts
+++ b/backend/typescript/middlewares/validators/camperValidators.ts
@@ -205,6 +205,7 @@ export const updateCamperDtoValidator = async (
       .status(400)
       .send("There must be at least one camperId specified.");
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (!req.body.camperIds.every((id: any) => validatePrimitive(id, "string"))) {
     return res
       .status(400)
@@ -286,6 +287,7 @@ export const deleteCamperDtoValidator = async (
       .status(400)
       .send("There must be at least one camperId specified.");
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (!req.body.camperIds.every((id: any) => validatePrimitive(id, "string"))) {
     return res
       .status(400)

--- a/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import {
   ModalOverlay,
@@ -69,6 +69,9 @@ const EditCamperModal = ({
     formResponses,
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const initialStateVariables = useMemo(() => stateVariables, []);
+
   const resetState = () => {
     setFirstName(camper.firstName);
     setLastName(camper.lastName);
@@ -78,12 +81,24 @@ const EditCamperModal = ({
     setFormResponses(camper.formResponses);
   };
 
-  const closeModal = () => {
+  useEffect(() => {
     resetState();
+  }, [camper]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const closeWithoutSaving = () => {
     editCamperModalOnClose();
+    /* eslint-disable */
+    setFirstName(initialStateVariables.firstName!);
+    setLastName(initialStateVariables.lastName!);
+    setAge(initialStateVariables.age!);
+    setAllergies(initialStateVariables.allergies!);
+    setSpecialNeeds(initialStateVariables.specialNeeds!);
+    setFormResponses(initialStateVariables.formResponses!);
+    /* eslint-enable */
   };
 
   const onSaveClicked = async () => {
+    editCamperModalOnClose();
     const editCamperFields: EditCamperInfoFields = {
       firstName,
       lastName,
@@ -98,7 +113,7 @@ const EditCamperModal = ({
       editCamperFields,
     );
     if (isEditCamperSuccess instanceof Error) {
-      closeModal();
+      closeWithoutSaving();
       toast({
         description: `An error occurred with updating ${camper.firstName} ${camper.lastName}'s information. Please try again.`,
         status: "error",
@@ -107,7 +122,7 @@ const EditCamperModal = ({
       });
     } else {
       // TODO: introduce global state so we don't have to refetch
-      closeModal();
+      closeWithoutSaving();
       toast({
         description: `${camper.firstName} ${camper.lastName}'s information has been updated`,
         status: "success",
@@ -140,7 +155,7 @@ const EditCamperModal = ({
 
         <ModalFooter>
           <Button
-            onClick={editCamperModalOnClose}
+            onClick={closeWithoutSaving}
             background="background.grey.100"
             padding="12px, 25px, 12px, 25px"
             borderRadius="6px"

--- a/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
+++ b/frontend/src/components/pages/CampOverview/EditCamperModal/index.tsx
@@ -69,8 +69,9 @@ const EditCamperModal = ({
     formResponses,
   };
 
+  const [updateMemo, setUpdateMemo] = useState(0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialStateVariables = useMemo(() => stateVariables, []);
+  const initialStateVariables = useMemo(() => stateVariables, [updateMemo]);
 
   const resetState = () => {
     setFirstName(camper.firstName);
@@ -82,11 +83,11 @@ const EditCamperModal = ({
   };
 
   useEffect(() => {
+    setUpdateMemo(updateMemo + 1);
     resetState();
   }, [camper]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const closeWithoutSaving = () => {
-    editCamperModalOnClose();
     /* eslint-disable */
     setFirstName(initialStateVariables.firstName!);
     setLastName(initialStateVariables.lastName!);
@@ -95,6 +96,7 @@ const EditCamperModal = ({
     setSpecialNeeds(initialStateVariables.specialNeeds!);
     setFormResponses(initialStateVariables.formResponses!);
     /* eslint-enable */
+    editCamperModalOnClose();
   };
 
   const onSaveClicked = async () => {
@@ -136,7 +138,7 @@ const EditCamperModal = ({
   return (
     <Modal
       isOpen={editCamperModalIsOpen}
-      onClose={editCamperModalOnClose}
+      onClose={closeWithoutSaving}
       preserveScrollBarGap
       isCentered
     >


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix camper edit functionality](https://www.notion.so/uwblueprintexecs/Fix-camper-edit-functionality-12b9fad2bae24cce9cf7352535ebc406)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a useEffect to ensure the changes were loaded every time there was a new camper clicked
* Added a useMemo to keep track of initial state to set back to if an admin clicks cancel (very similar to what I did for all the edit components in the ReviewRegistration step, registrant experience).


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to any camp with campers, http://localhost:3000/admin/camp/6397f94e2ff11dcda0ba4960 works well.
2. Try to edit (multiple) campers, the initial information loaded should all be correct now and of the clicked camper.
3. Click save, cancel, click outside of the modal (another way to cancel), and ensure everything behaves as expected now.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, functionality.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
