### PR TITLE
Add HST not required to ‘Total’ copy on payment review & confirmation page

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationResult/index.tsx
@@ -51,7 +51,9 @@ const PaymentSummaryList = ({
         ))}
       </VStack>
       <HStack w="100%" justify="space-between">
-        <Text textStyle={cardBoldStyles}>Total</Text>
+        <Text textStyle={cardBoldStyles}>
+          Total <Text as="i">(HST not required)</Text>
+        </Text>
         <Text textStyle={cardBoldStyles}>${calculateTotalPrice(items)}</Text>
       </HStack>
     </VStack>

--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/PaymentSummary.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/ReviewRegistration/PaymentSummary.tsx
@@ -140,7 +140,9 @@ const PaymentSummary = ({
         my={4}
         w={{ base: "100%", lg: "450px" }}
       >
-        <Text textStyle={totalRowTextStyles}>Total</Text>
+        <Text textStyle={totalRowTextStyles}>
+          Total <Text as="i">(HST not required)</Text>
+        </Text>
         <Text textStyle={totalRowTextStyles}>
           ${calculateTotalPrice(items).toFixed(2)}
         </Text>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add HST not required to ‘Total’ copy on payment review & confirmation page](https://www.notion.so/uwblueprintexecs/Add-HST-not-required-to-Total-copy-on-payment-review-confirmation-page-ef4d474b8ae0423fa79bf08a383e9ab0?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added an italicized `<Text>`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Register a camper.
2. 
![image](https://user-images.githubusercontent.com/30396273/217717445-2e50472b-4813-45c4-b857-5dea4ccf75d0.png)



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
