### PR TITLE
Fix: Manage sessions doesn’t persist

### DIFF
--- a/backend/typescript/middlewares/validators/campValidators.ts
+++ b/backend/typescript/middlewares/validators/campValidators.ts
@@ -356,7 +356,7 @@ export const updateCampSessionsDtoValidator = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const body = req.body.data;
+  const { body } = req;
   if (!body) {
     return res.status(400).send("no data found in request body");
   }

--- a/backend/typescript/rest/campRoutes.ts
+++ b/backend/typescript/rest/campRoutes.ts
@@ -217,7 +217,7 @@ campRouter.patch(
     try {
       const campSession = await campService.updateCampSessionsByIds(
         req.params.campId,
-        req.body.data.updatedCampSessions,
+        req.body.updatedCampSessions,
       );
       res.status(200).json(campSession);
     } catch (error: unknown) {

--- a/frontend/src/APIClients/CampsAPIClient.ts
+++ b/frontend/src/APIClients/CampsAPIClient.ts
@@ -105,7 +105,9 @@ const updateCampSessions = async (
   updatedCampSessions: Array<UpdateCampSessionsRequest>,
 ): Promise<Array<CampSessionResponse>> => {
   try {
-    const { data } = await baseAPIClient.patch(`/camp/${campId}/session`, {
+    const { data } = await baseAPIClient({
+      method: "patch",
+      url: `/camp/${campId}/session`,
       headers: {
         Authorization: getBearerToken(),
       },


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Management Experience] Manage sessions doesn’t persist](https://www.notion.so/uwblueprintexecs/Management-Experience-Manage-sessions-doesn-t-persist-cec1071f9d9a4cd980973cc6a9e388ab?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed the format of the patch so that it would actually use the authorization headers
* Changed the validators too to account for this.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Note: This is only going to work after pr #267 is merged.
2. Go to any camp and click the manage sessions button on the right.
3. Changing session capacity should work now, deletion worked anyway.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, functionality.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
