### PR TITLE
Camp Overview: Sort waitlisted campers by created at date

### DIFF
--- a/backend/typescript/models/waitlistedCamper.model.ts
+++ b/backend/typescript/models/waitlistedCamper.model.ts
@@ -13,6 +13,7 @@ export interface WaitlistedCamper extends Document {
   status: WaitlistedCamperStatus;
   campSession: Schema.Types.ObjectId;
   linkExpiry?: Date;
+  registrationDate: Date;
 }
 
 const WaitlistedCamperSchema: Schema = new Schema({
@@ -57,6 +58,10 @@ const WaitlistedCamperSchema: Schema = new Schema({
   },
   linkExpiry: {
     type: Date,
+  },
+  registrationDate: {
+    type: Date,
+    required: true,
   },
 });
 

--- a/backend/typescript/services/implementations/campService.ts
+++ b/backend/typescript/services/implementations/campService.ts
@@ -147,6 +147,7 @@ class CampService implements ICampService {
                     contactEmail: waitlistedCamper.contactEmail,
                     contactNumber: waitlistedCamper.contactNumber,
                     status: waitlistedCamper.status,
+                    registrationDate: waitlistedCamper.registrationDate.toString(),
                   };
                 },
               );
@@ -314,6 +315,7 @@ class CampService implements ICampService {
               contactNumber: waitlistedCamper.contactNumber,
               status: waitlistedCamper.status,
               linkExpiry: waitlistedCamper.linkExpiry,
+              registrationDate: waitlistedCamper.registrationDate.toString(),
             };
           },
         );

--- a/backend/typescript/services/implementations/camperService.ts
+++ b/backend/typescript/services/implementations/camperService.ts
@@ -396,6 +396,7 @@ class CamperService implements ICamperService {
           contactNumber: camper.contactNumber,
           campSession: camper.campSession ? camper.campSession.toString() : "",
           status: camper.status,
+          registrationDate: camper.registrationDate.toString(),
         };
       });
     } catch (error: unknown) {
@@ -595,6 +596,7 @@ class CamperService implements ICamperService {
             contactNumber: waitlistedCamper.contactNumber,
             campSession: cs,
             status: "NotRegistered",
+            registrationDate: new Date().toString(),
           };
         });
       });
@@ -646,6 +648,7 @@ class CamperService implements ICamperService {
         contactNumber: c.contactNumber,
         campSession: c.campSession.toString(),
         status: c.status,
+        registrationDate: c.registrationDate.toString(),
       };
     });
   }
@@ -1154,6 +1157,7 @@ class CamperService implements ICamperService {
           contactNumber: camperToUpdate.contactNumber,
           campSession: camperToUpdate.campSession,
           status: camperToUpdate.status,
+          registrationDate: camperToUpdate.registrationDate,
         };
     } catch (error: unknown) {
       Logger.error(

--- a/backend/typescript/types.ts
+++ b/backend/typescript/types.ts
@@ -114,6 +114,7 @@ export type WaitlistedCamperDTO = {
   campSession: string;
   status: WaitlistedCamperStatus;
   linkExpiry?: Date;
+  registrationDate: string;
 };
 
 export type CreateUserDTO = Omit<UserDTO, "id">;
@@ -228,7 +229,7 @@ export type CreateCampersDTO = Array<
 
 export type CreateWaitlistedCamperDTO = Omit<
   WaitlistedCamperDTO,
-  "id" | "campSession" | "status" | "linkExpiry"
+  "id" | "campSession" | "status" | "linkExpiry" | "registrationDate"
 >;
 
 export type UpdateCamperDTO = Omit<

--- a/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
+++ b/frontend/src/components/pages/CampOverview/CampersTable/WaitlistedCampersTable.tsx
@@ -50,8 +50,15 @@ const WaitlistedCampersTable = ({
     setCamperToDelete,
   ] = React.useState<WaitlistedCamper | null>(null);
 
+  const sortedCampers = waitlistedCampers.sort((camper1, camper2) => {
+    return (
+      new Date(camper1.registrationDate).getTime() -
+      new Date(camper2.registrationDate).getTime()
+    );
+  });
+
   const tableData = React.useMemo(() => {
-    const filteredCampers = waitlistedCampers;
+    const filteredCampers = sortedCampers;
 
     if (!search) return filteredCampers;
     return filteredCampers.filter((camper: WaitlistedCamper) =>
@@ -60,7 +67,7 @@ const WaitlistedCampersTable = ({
         .concat(" ", camper.lastName.toLowerCase())
         .includes(search.toLowerCase()),
     );
-  }, [search, waitlistedCampers]);
+  }, [search, sortedCampers]);
 
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/frontend/src/types/CamperTypes.ts
+++ b/frontend/src/types/CamperTypes.ts
@@ -92,11 +92,12 @@ export type WaitlistedCamper = {
   campSession: string;
   status: WaitlistedCamperStatus;
   linkExpiry?: Date;
+  registrationDate: Date;
 };
 
 export type CreateWaitlistedCamperDTO = Omit<
   WaitlistedCamper,
-  "id" | "campSession" | "status" | "linkExpiry"
+  "id" | "campSession" | "status" | "linkExpiry" | "registrationDate"
 >;
 
 export type CreateCamperResponse = {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Overview: Sort waitlisted campers by created at date](https://www.notion.so/uwblueprintexecs/Camp-Overview-Sort-waitlisted-campers-by-created-at-date-d3df8b367eba444a988a58c56fc7f6ce?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a registrationDate property to waitlisted camper DTOs and schema, and also implemented it whereever needed (pretty much look at whereever waitlisted campers were being used and added the new property there, trying to recreate what we did with the regular camper dtos).


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Note: This PR will only work properly after PR #267 is submitted, so I'll draft it until then.
2. Register some campers on a waitlist
3. Ensure that they are sorted in the order you created them in (by registrationDate).


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correctness, functionality.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
