### PR TITLE
Add legacy openssl flag to build command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "react-json-schema": "^1.2.2",
     "react-jsonschema-form": "^1.8.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.2", // Perhaps the problem (temp comment).
+    "react-scripts": "4.0.2",
     "react-table": "^7.7.0",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "react-json-schema": "^1.2.2",
     "react-jsonschema-form": "^1.8.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.2",
+    "react-scripts": "4.0.2", // Perhaps the problem (temp comment).
     "react-table": "^7.7.0",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@chakra-ui/react": "^2.2.1",
-    "@fortawesome/fontawesome-free": "^6.1.1",
-    "react-scripts": "^5.0.1"
+    "@fortawesome/fontawesome-free": "^6.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@chakra-ui/react": "^2.2.1",
-    "@fortawesome/fontawesome-free": "^6.1.1"
+    "@fortawesome/fontawesome-free": "^6.1.1",
+    "react-scripts": "^5.0.1"
   }
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Firebase build (staging) not working](https://www.notion.so/uwblueprintexecs/Firebase-build-staging-not-working-01b4a6d16be34448a3a546d76367679d?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a flag to the build command that uses a legacy provider to solve the error (which happens due to the newer version of nodejs)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. See if deployment is successful.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensure it works.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
