### PR TITLE
fix: docker build failing on old line

### DIFF
--- a/backend/typescript/Dockerfile
+++ b/backend/typescript/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY package.json yarn.lock tsconfig.json ./
 
 # libcurl3 is required for mongodb-memory-server, which is used for testing
-RUN apt-get update && apt-get install -y libcurl3
+# RUN apt-get update && apt-get install -y libcurl3
 
 RUN yarn install
 


### PR DESCRIPTION
Comment out old line that was causing:
![image](https://github.com/uwblueprint/focus-on-nature/assets/41273929/5bfab776-431a-4ca0-a77f-31793b6d9c75)
![image (1)](https://github.com/uwblueprint/focus-on-nature/assets/41273929/024dc145-e03e-48e6-9e51-d84e7a3e659c)
