### PR TITLE
fix: Add current session date validation on camp creation flow

### DIFF
--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/CurrentSessionsView.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/CurrentSessionsView.tsx
@@ -19,12 +19,14 @@ type CurrentSessionsViewProps = {
   scheduledSessions: CreateCampSession[];
   setScheduledSessions: (sessions: Array<CreateCampSession>) => void;
   setShowAddSessions: (showView: boolean) => void;
+  showScheduleSessionCardError: boolean;
 };
 
 const CurrentSessionsView = ({
   scheduledSessions,
   setScheduledSessions,
   setShowAddSessions,
+  showScheduleSessionCardError,
 }: CurrentSessionsViewProps): JSX.Element => {
   const [sessionToDeleteIndex, setSessionToDeleteIndex] = React.useState(0);
   const toast = useToast();
@@ -92,6 +94,7 @@ const CurrentSessionsView = ({
                 scheduledSession={session}
                 updateSession={updateSession}
                 onDelete={deleteSession}
+                showScheduleSessionCardError={showScheduleSessionCardError}
               />
             ))}
           </>

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
@@ -1,5 +1,14 @@
 import React from "react";
-import { Box, HStack, Text, Button, Wrap, WrapItem, FormControl, FormErrorMessage } from "@chakra-ui/react";
+import {
+  Box,
+  HStack,
+  Text,
+  Button,
+  Wrap,
+  WrapItem,
+  FormControl,
+  FormErrorMessage,
+} from "@chakra-ui/react";
 import SessionDayButton from "./SessionDayButton";
 import { CreateCampSession } from "../../../../../types/CampsTypes";
 import {
@@ -97,9 +106,7 @@ const ScheduledSessionsCard = ({
         </Box>
       </Box>
       {showScheduleSessionCardError && scheduledSession.dates.length === 0 && (
-        <FormErrorMessage>
-          Please select at least one day.
-        </FormErrorMessage>
+        <FormErrorMessage>Please select at least one day.</FormErrorMessage>
       )}
     </FormControl>
   );

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/ScheduledSessionsCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, HStack, Text, Button, Wrap, WrapItem } from "@chakra-ui/react";
+import { Box, HStack, Text, Button, Wrap, WrapItem, FormControl, FormErrorMessage } from "@chakra-ui/react";
 import SessionDayButton from "./SessionDayButton";
 import { CreateCampSession } from "../../../../../types/CampsTypes";
 import {
@@ -13,6 +13,7 @@ type ScheduledSessionsCardProps = {
   scheduledSession: CreateCampSession;
   updateSession: (index: number, updatedSession: CreateCampSession) => void;
   onDelete: (index: number) => void;
+  showScheduleSessionCardError: boolean;
 };
 
 const ScheduledSessionsCard = ({
@@ -20,6 +21,7 @@ const ScheduledSessionsCard = ({
   scheduledSession,
   updateSession,
   onDelete,
+  showScheduleSessionCardError,
 }: ScheduledSessionsCardProps): React.ReactElement => {
   const sessionDatesRangeString = getFormattedDateRangeStringFromDateArray(
     scheduledSession.dates,
@@ -50,50 +52,56 @@ const ScheduledSessionsCard = ({
       dates: updatedDates,
       selectedWeekDays: updatedWeekDays,
     };
-
     updateSession(currIndex, updatedScheduledSession);
   };
 
   return (
-    <Box
-      key={currIndex}
-      backgroundColor="background.white.100"
-      width="100%"
-      padding={5}
-      borderRadius={10}
-      borderColor={getSessionBorderColor(currIndex)}
-      borderWidth="1.75px"
-    >
-      <Box alignItems="flex-start" flexDirection="column">
-        <HStack justifyContent="space-between" w="full">
-          <Text textStyle="displayMediumBold">{`Session ${
-            currIndex + 1
-          }`}</Text>
-          <Button
-            onClick={() => onDelete(currIndex)}
-            bgColor="background.white.100"
-            color="text.critical.100"
-            _hover={{ bg: "background.grey.100" }}
-          >
-            Delete
-          </Button>
-        </HStack>
-        <Text marginBottom={3} textStyle="bodyRegular">
-          {sessionDatesRangeString}
-        </Text>
-        <Wrap>
-          {Array.from(selectedWeekDays.keys()).map((day) => (
-            <WrapItem key={day}>
-              <SessionDayButton
-                day={day}
-                selected={selectedWeekDays.get(day)}
-                onSelect={updateSelectedSessionDays}
-              />
-            </WrapItem>
-          ))}
-        </Wrap>
+    <FormControl isInvalid={showScheduleSessionCardError}>
+      <Box
+        key={currIndex}
+        backgroundColor="background.white.100"
+        width="100%"
+        padding={5}
+        borderRadius={10}
+        borderColor={getSessionBorderColor(currIndex)}
+        borderWidth="1.75px"
+      >
+        <Box alignItems="flex-start" flexDirection="column">
+          <HStack justifyContent="space-between" w="full">
+            <Text textStyle="displayMediumBold">
+              {`Session ${currIndex + 1}`}
+            </Text>
+            <Button
+              onClick={() => onDelete(currIndex)}
+              bgColor="background.white.100"
+              color="text.critical.100"
+              _hover={{ bg: "background.grey.100" }}
+            >
+              Delete
+            </Button>
+          </HStack>
+          <Text marginBottom={3} textStyle="bodyRegular">
+            {sessionDatesRangeString}
+          </Text>
+          <Wrap>
+            {Array.from(selectedWeekDays.keys()).map((day) => (
+              <WrapItem key={day}>
+                <SessionDayButton
+                  day={day}
+                  selected={selectedWeekDays.get(day)}
+                  onSelect={updateSelectedSessionDays}
+                />
+              </WrapItem>
+            ))}
+          </Wrap>
+        </Box>
       </Box>
-    </Box>
+      {showScheduleSessionCardError && scheduledSession.dates.length === 0 && (
+        <FormErrorMessage>
+          Please select at least one day.
+        </FormErrorMessage>
+      )}
+    </FormControl>
   );
 };
 

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/SessionSidePanel.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/SessionSidePanel.tsx
@@ -7,11 +7,13 @@ import { CreateCampSession } from "../../../../../types/CampsTypes";
 type SessionSidePanelProps = {
   scheduledSessions: CreateCampSession[];
   setScheduledSessions: (sessions: Array<CreateCampSession>) => void;
+  showScheduleSessionCardError: boolean;
 };
 
 const SessionSidePanel = ({
   scheduledSessions,
   setScheduledSessions,
+  showScheduleSessionCardError,
 }: SessionSidePanelProps): React.ReactElement => {
   const [showAddSessionView, setShowAddSessionView] = React.useState(false);
 
@@ -36,6 +38,7 @@ const SessionSidePanel = ({
           scheduledSessions={scheduledSessions}
           setScheduledSessions={setScheduledSessions}
           setShowAddSessions={setShowAddSessionView}
+          showScheduleSessionCardError={showScheduleSessionCardError}
         />
       )}
     </Box>

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/index.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/index.tsx
@@ -14,7 +14,6 @@ const SessionSidePanel = ({
   scheduledSessions,
   setScheduledSessions,
   showScheduleSessionCardError,
-  
 }: SessionSidePanelProps): React.ReactElement => {
   const [showAddSessionView, setShowAddSessionView] = React.useState(false);
 

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/index.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/SidePanel/index.tsx
@@ -7,11 +7,14 @@ import { CreateCampSession } from "../../../../../types/CampsTypes";
 type SessionSidePanelProps = {
   scheduledSessions: CreateCampSession[];
   setScheduledSessions: (sessions: Array<CreateCampSession>) => void;
+  showScheduleSessionCardError: boolean;
 };
 
 const SessionSidePanel = ({
   scheduledSessions,
   setScheduledSessions,
+  showScheduleSessionCardError,
+  
 }: SessionSidePanelProps): React.ReactElement => {
   const [showAddSessionView, setShowAddSessionView] = React.useState(false);
 
@@ -28,6 +31,7 @@ const SessionSidePanel = ({
           scheduledSessions={scheduledSessions}
           setScheduledSessions={setScheduledSessions}
           setShowAddSessions={setShowAddSessionView}
+          showScheduleSessionCardError={showScheduleSessionCardError}
         />
       )}
     </Box>

--- a/frontend/src/components/pages/CampCreation/ScheduleSessions/index.tsx
+++ b/frontend/src/components/pages/CampCreation/ScheduleSessions/index.tsx
@@ -8,12 +8,14 @@ type ScheduleSessionsProps = {
   campTitle: string;
   scheduledSessions: CreateCampSession[];
   setScheduledSessions: (newSessions: CreateCampSession[]) => void;
+  showScheduleSessionCardError: boolean;
 };
 
 const ScheduleSessions = ({
   campTitle,
   scheduledSessions,
   setScheduledSessions,
+  showScheduleSessionCardError,
 }: ScheduleSessionsProps): React.ReactElement => {
   return (
     <Flex justify="flex-end" w="100%" h="100%">
@@ -29,6 +31,7 @@ const ScheduleSessions = ({
       <SessionSidePanel
         scheduledSessions={scheduledSessions}
         setScheduledSessions={setScheduledSessions}
+        showScheduleSessionCardError={showScheduleSessionCardError}
       />
     </Flex>
   );

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -48,7 +48,10 @@ const CampCreationPage = (): React.ReactElement => {
   const [scheduledSessions, setScheduledSessions] = React.useState<
     CreateCampSession[]
   >([]);
-  const [showScheduleSessionCardError, setShowScheduleSessionCardError] = React.useState<boolean>(false)
+  const [
+    showScheduleSessionCardError,
+    setShowScheduleSessionCardError,
+  ] = React.useState<boolean>(false);
 
   const [visitedRegistrationPage, setVisitedRegistrationPage] = useState(false);
   const [showCreationErrors, setShowCreationErrors] = useState<boolean>(false);
@@ -109,7 +112,7 @@ const CampCreationPage = (): React.ReactElement => {
     latestPickUpTime,
     true,
   );
-  
+
   // Check if Camp Details are filled in
   if (
     campName &&
@@ -137,7 +140,7 @@ const CampCreationPage = (): React.ReactElement => {
   )
     isCampDetailsFilled = true;
   else isCampDetailsFilled = false;
-  
+
   const isScheduleSessionsFilled = scheduledSessions.length !== 0;
   const isRegistrationFormFilled = visitedRegistrationPage;
 
@@ -520,9 +523,15 @@ const CampCreationPage = (): React.ReactElement => {
   };
 
   const handleStepNavigation = (stepsToMove: number) => {
-    const invalidScheduleCard = !scheduledSessions.every(session => session.dates.length !== 0)
-    if (stepsToMove > 0 && currentPage === CampCreationPages.ScheduleSessionsPage && invalidScheduleCard) {
-      setShowScheduleSessionCardError(invalidScheduleCard)
+    const invalidScheduleCard = !scheduledSessions.every(
+      (session) => session.dates.length !== 0,
+    );
+    if (
+      stepsToMove > 0 &&
+      currentPage === CampCreationPages.ScheduleSessionsPage &&
+      invalidScheduleCard
+    ) {
+      setShowScheduleSessionCardError(invalidScheduleCard);
       return;
     }
 
@@ -531,7 +540,6 @@ const CampCreationPage = (): React.ReactElement => {
       setCurrentPage(currentPage + stepsToMove);
     }
   };
-
 
   return (
     <VStack w="100vw" h="calc(100vh - 75px)">

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -48,9 +48,9 @@ const CampCreationPage = (): React.ReactElement => {
   const [scheduledSessions, setScheduledSessions] = React.useState<
     CreateCampSession[]
   >([]);
+  const [showScheduleSessionCardError, setShowScheduleSessionCardError] = React.useState<boolean>(false)
 
   const [visitedRegistrationPage, setVisitedRegistrationPage] = useState(false);
-
   const [showCreationErrors, setShowCreationErrors] = useState<boolean>(false);
 
   // Variables to determine whether or not all required fields have been filled out.
@@ -109,7 +109,8 @@ const CampCreationPage = (): React.ReactElement => {
     latestPickUpTime,
     true,
   );
-
+  
+  // Check if Camp Details are filled in
   if (
     campName &&
     campDescription &&
@@ -136,7 +137,7 @@ const CampCreationPage = (): React.ReactElement => {
   )
     isCampDetailsFilled = true;
   else isCampDetailsFilled = false;
-
+  
   const isScheduleSessionsFilled = scheduledSessions.length !== 0;
   const isRegistrationFormFilled = visitedRegistrationPage;
 
@@ -496,6 +497,7 @@ const CampCreationPage = (): React.ReactElement => {
             campTitle={`${campName} @${startTime} - ${endTime}`}
             scheduledSessions={scheduledSessions}
             setScheduledSessions={setScheduledSessions}
+            showScheduleSessionCardError={showScheduleSessionCardError}
           />
         );
       case CampCreationPages.RegistrationFormPage:
@@ -518,11 +520,18 @@ const CampCreationPage = (): React.ReactElement => {
   };
 
   const handleStepNavigation = (stepsToMove: number) => {
+    const invalidScheduleCard = !scheduledSessions.every(session => session.dates.length !== 0)
+    if (stepsToMove > 0 && currentPage === CampCreationPages.ScheduleSessionsPage && invalidScheduleCard) {
+      setShowScheduleSessionCardError(invalidScheduleCard)
+      return;
+    }
+
     const desiredStep = currentPage + stepsToMove;
     if (CampCreationPages[desiredStep]) {
       setCurrentPage(currentPage + stepsToMove);
     }
   };
+
 
   return (
     <VStack w="100vw" h="calc(100vh - 75px)">

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -523,14 +523,11 @@ const CampCreationPage = (): React.ReactElement => {
   };
 
   const handleStepNavigation = (stepsToMove: number) => {
-    const invalidScheduleCard = !scheduledSessions.every(
-      (session) => session.dates.length !== 0,
-    );
-    if (
+    const invalidScheduleCard =
+      !scheduledSessions.every((session) => session.dates.length !== 0) &&
       stepsToMove > 0 &&
-      currentPage === CampCreationPages.ScheduleSessionsPage &&
-      invalidScheduleCard
-    ) {
+      currentPage === CampCreationPages.ScheduleSessionsPage;
+    if (invalidScheduleCard) {
       setShowScheduleSessionCardError(invalidScheduleCard);
       return;
     }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[[Camp Creation] Ensure at least one date is selected for each session](https://www.notion.so/uwblueprintexecs/Camp-Creation-Ensure-at-least-one-date-is-selected-for-each-session-f0b82559812e4b7ebff5f7cf4c528f42?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added flag in `CurrentSessionsView.tsx` to keep track of error handling 
* Wrapped ScheduledSessionsCard with chakra FormControl and associated FormErrorMessage
* Prevented user from clicking next button if any ScheduledSessionCard had no dates selected


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Enter Add a camp flow `admin/add-camp`
2. Fill out camp details and click Next
3. Select some dates and add a camp session
4. Edit camp session to have no dates
5. Click Next
6. Error message is displayed and user cannot proceed to the next step


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
