### PR TITLE
fix: sorted session dates in registration emails

### DIFF
--- a/backend/typescript/services/implementations/emailService.ts
+++ b/backend/typescript/services/implementations/emailService.ts
@@ -23,7 +23,7 @@ function sessionDatesToString(dates: Date[] | undefined) {
 // Returns a list item for each camp session with the dates of the camp session
 function getSessionDatesListItems(campSessions: CampSession[]) {
   campSessions.map((campSession) => {
-    campSession.dates.sort((a, b) => {
+    return campSession.dates.sort((a, b) => {
       return a.getTime() - b.getTime();
     });
   });

--- a/backend/typescript/services/implementations/emailService.ts
+++ b/backend/typescript/services/implementations/emailService.ts
@@ -22,6 +22,11 @@ function sessionDatesToString(dates: Date[] | undefined) {
 
 // Returns a list item for each camp session with the dates of the camp session
 function getSessionDatesListItems(campSessions: CampSession[]) {
+  campSessions.map((campSession) => {
+    campSession.dates.sort((a, b) => {
+      return a.getTime() - b.getTime();
+    });
+  });
   return campSessions.map((campSession) => {
     return `<li>${sessionDatesToString(campSession.dates)}</li>`;
   });


### PR DESCRIPTION
## Notion ticket link
[Sort session dates in waitlist registration email](https://www.notion.so/uwblueprintexecs/Sort-session-dates-in-waitlist-registration-email-1783b7485e8b443d99c1f43a89a2f663)


## Implementation description
* Added a sorting function for camp session dates before converting dates into strings for parent emails.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/register/camp/6484d0b47f142e45f5c30afe. There should be a total of 4 different sessions with varying session dates. Click on any random one
2. Fill in the required fields and register/waitlist a "camper" using an accessible email.
3. Once registration is completed, check the email for an email from FON. The dates under "Session Dates" should be sorted from earliest to latest
![image](https://github.com/uwblueprint/focus-on-nature/assets/86946736/91a18a31-8a91-4580-9cc9-89c5c935a7f6)


## What should reviewers focus on?
* Check if sorting works across all different session dates


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
