### PR TITLE
fix: allow user to deselect multiselect options containing commas

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/QuestionGroups/MultiselectGroup.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/QuestionGroups/MultiselectGroup.tsx
@@ -33,7 +33,7 @@ const MultiselectGroup = ({
   const getInitialSelections = (): Set<string> => {
     const questionResponse = formResponses?.get(question.question);
     if (questionResponse) {
-      const items = questionResponse.split(", ");
+      const items = questionResponse.split("@ ");
       return new Set(items);
     }
     return new Set();
@@ -58,7 +58,7 @@ const MultiselectGroup = ({
     }
 
     setSelections(newSelections);
-    const selectionsResponse = Array.from(newSelections).join(", ");
+    const selectionsResponse = Array.from(newSelections).join("@ ");
 
     handleSelectionChange(selectionsResponse, question);
   };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Additional Info Checkbox work for options with a comma in it](https://www.notion.so/uwblueprintexecs/Additional-Info-Checkbox-work-for-options-with-a-comma-in-it-1a30e34ab60447e4a2b13c80983ad12e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Changed multiselect boxes delimiter from "," to "@" (less predictable symbol) to separate the set of selected options because one multiselect option contains ","


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/register/camp/6396319f01dd5e987a03b516
2. Select an available camp session. If none present, create one and select it.
3. Fill in all required fields in "Personal Info" section. Select "Next".
4. Under "Additional Info" section, under "Camper-specific Additional Questions", try different combinations of enabling and disabling all options. Then, fill in other required information in this section. Select "Next"
5. Fill in all required fields in "Waiver" section. Select "Next".
6. Under "Review & Pay" section, under "Additional Information" accordion section, select "Edit" and play around with multiselect options. "all day, every day" can now be disabled. Click "Save". 
7. Click "Back" until we reach "Additional Info" again. Now, "all day, every day" can be disabled.

![fix-allow user to deselect multiselect options containing commas](https://github.com/uwblueprint/focus-on-nature/assets/25796421/4fe2b832-7e3a-4188-9198-9cf26ca621e2)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Check if all multiselect combinations work 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
