### PR TITLE
fix: allow user to change from short answer to multiple choice with rendered default option

### DIFF
--- a/frontend/src/components/common/formQuestions/AddQuestionModal/QuestionOptionSection.tsx
+++ b/frontend/src/components/common/formQuestions/AddQuestionModal/QuestionOptionSection.tsx
@@ -33,7 +33,8 @@ const QuestionOptionSection = ({
       existingOptions.push({ option });
     });
   }
-  if (!optionsToBeEdited) existingOptions = [{ option: "" }];
+
+  if (!optionsToBeEdited || optionsToBeEdited.length === 0) existingOptions = [{ option: "" }];
   const [options, setOptions] = useState<Array<Option>>(existingOptions);
 
   const handleFormChange = (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Camp Editing: Changing from text to multiple choice doesn’t render option](https://www.notion.so/uwblueprintexecs/Camp-Editing-Changing-from-text-to-multiple-choice-doesn-t-render-option-419cad42c01d477392290b1530eff18c?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* checked if `optionsToBeEdited` array was empty; if empty, set `option` field to empty string to render an empty options field for "Multiple choice" and "Checkbox"


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to [site](http://localhost:3000/admin/edit-camp/63b01ddec71ee220ef84daeb)
2. Click "Step 3/3 Registration Form" header
3. Expand "Camper Information" accordion dropdown
4. Click "Edit" on "10. How does the camper feel about rock climbing?" 
5. Click "Question Type" and change from "Short answer" to "Multiple choice" or "Checkbox" (if "Question type" is already set to "Short answer", select another question that can be edited that is set to "Short answer")
6. There should be an empty prompt that automatically renders after changing from "Short answer" to "Multiple choice" or "Checkbox"
7. Fill the prompts with options (e.g. "Yes" , "No", "Maybe")
8. Click "Save question"
9. Click back into the same question and see if the "Question type" has changed and the options are properly saved
10. Click "Publish" at the bottom to save changes 
11. Visit the camp's information and check if all the changes were saved

![fix-allow user to change from short answer to multiple choice with rendered default option](https://github.com/uwblueprint/focus-on-nature/assets/25796421/8bde667e-332f-41c2-9ecf-a0954c46d676)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Changes to "Question type" for all camps are saved properly and changing from "Short answer" to "Multiple choice"/"Checkbox" displays default empty prompt


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
