### PR TITLE
tina-nathan/payment-failed-modal

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -162,7 +162,12 @@ const RegistrantExperiencePage = (): React.ReactElement => {
         // recognize this change and regenerate a new checkout link, and notify them of the change in
         // checkout items. Checkouts expire within a day (?) so it's a very limited case.
         setSelectedSessions(new Set(cachedRegistration.selectedSessionIds));
-        setCurrentStep("registration");
+        // Other case -- if they complete Stripe checkout successfully and come back
+        // current step has been set to registrationResult
+        if (registrationResult !== SUCCESS_RESULT_CODE) {
+          // only set current step to registration if checkout hasn't been completed yet
+          setCurrentStep("registration");
+        }
         setCamp(cachedRegistration.camp);
         setWaiver(cachedRegistration.waiverInterface.waiver);
       }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Payment Failed Modal](https://www.notion.so/uwblueprintexecs/Payment-Failed-Modal-b7228f36e326471696f0aa9efac733a0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add check to prevent current step to be set to registration after checkout has been completed


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go through the register flow to signup for a camp
2. Verify that checkout is successful and directed to registration result page (example below)
<img width="1222" alt="Screen Shot 2023-07-22 at 4 04 23 PM" src="https://github.com/uwblueprint/focus-on-nature/assets/88808428/2055380a-ded1-4e3e-8675-3745989399c8">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* If checkout fails the error modal should be displayed

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
