### PR TITLE
Fix: Persist data from Personal Info in Available Sessions Page

### DIFF
--- a/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/RegistrationSteps/index.tsx
@@ -6,6 +6,8 @@ import React, {
   useRef,
   useEffect,
   useMemo,
+  SetStateAction,
+  Dispatch,
 } from "react";
 import { CampResponse, CampSession } from "../../../../types/CampsTypes";
 import {
@@ -43,6 +45,8 @@ import { EDLP_PLACEHOLDER_TIMESLOT } from "../../../../constants/RegistrationCon
 
 type RegistrationStepsProps = {
   camp: CampResponse;
+  campers: RegistrantExperienceCamper[];
+  setCampers: Dispatch<SetStateAction<RegistrantExperienceCamper[]>>;
   orderedSelectedSessions: CampSession[];
   waiver: WaiverType;
   waitlistedCamper?: WaitlistedCamper;
@@ -52,6 +56,8 @@ type RegistrationStepsProps = {
 
 const RegistrationSteps = ({
   camp,
+  campers,
+  setCampers,
   orderedSelectedSessions: selectedSessions,
   waiver,
   onClickBack,
@@ -71,30 +77,6 @@ const RegistrationSteps = ({
 
   const [isEditing, setIsEditing] = useState(0);
 
-  const [campers, setCampers] = useState<RegistrantExperienceCamper[]>([
-    {
-      firstName: "",
-      lastName: "",
-      age: NaN,
-      contacts: [
-        {
-          firstName: "",
-          lastName: "",
-          email: "",
-          phoneNumber: "",
-          relationshipToCamper: "",
-        },
-        {
-          firstName: "",
-          lastName: "",
-          email: "",
-          phoneNumber: "",
-          relationshipToCamper: "",
-        },
-      ],
-      optionalClauses: [],
-    },
-  ]);
 
   const [
     requireEarlyDropOffLatePickup,

--- a/frontend/src/components/pages/RegistrantExperience/index.tsx
+++ b/frontend/src/components/pages/RegistrantExperience/index.tsx
@@ -11,7 +11,7 @@ import RegistrationResultPage from "./RegistrationResult";
 import RegistrationSteps from "./RegistrationSteps";
 import SessionSelection from "./SessionSelection";
 import AdminAPIClient from "../../../APIClients/AdminAPIClient";
-import { WaitlistedCamper } from "../../../types/CamperTypes";
+import { RegistrantExperienceCamper, WaitlistedCamper } from "../../../types/CamperTypes";
 import { Waiver as WaiverType } from "../../../types/AdminTypes";
 import { sortSessions } from "../../../utils/CampUtils";
 import WaitlistExperiencePage from "../WaitlistExperience";
@@ -59,6 +59,32 @@ const RegistrantExperiencePage = (): React.ReactElement => {
     CheckoutData | undefined
   >(undefined);
 
+  const [campers, setCampers] = useState<RegistrantExperienceCamper[]>([
+    {
+      firstName: "",
+      lastName: "",
+      age: NaN,
+      contacts: [
+        {
+          firstName: "",
+          lastName: "",
+          email: "",
+          phoneNumber: "",
+          relationshipToCamper: "",
+        },
+        {
+          firstName: "",
+          lastName: "",
+          email: "",
+          phoneNumber: "",
+          relationshipToCamper: "",
+        },
+      ],
+      optionalClauses: [],
+    },
+  ]);
+
+
   const getCurrentStep = () => {
     switch (currentStep) {
       case "loading":
@@ -82,6 +108,8 @@ const RegistrantExperiencePage = (): React.ReactElement => {
         return (
           <RegistrationSteps
             camp={camp as CampResponse}
+            campers={campers}
+            setCampers={setCampers}
             orderedSelectedSessions={sortSessions(
               (camp as CampResponse).campSessions.filter((session) =>
                 selectedSessions.has(session.id),


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Registration: Existing registration details don’t persist if a parent returns from session selection](https://www.notion.so/uwblueprintexecs/Registration-Existing-registration-details-don-t-persist-if-a-parent-returns-from-session-selection-db97178c747843d69cf9d7b22b0142b4?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Move the useState initialization of the RegistrantExperienceCamper array to the RegistrantExperience page instead of inside the RegistrationSteps page 
* Pass the state and setter into the RegistrationSteps component


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to the registration page for a camp 
2. Fill out all the info for Step 1 - Personal Info
3. Click the next button 
4. Go back twice to the Available Session page
5. The Personal Info data that was filled out should persist


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
