### PR TITLE
feat: add validation for non-negative EDLP amount

### DIFF
--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -433,7 +433,9 @@ const CampCreationDetails = ({
               type="number"
               placeholder="0.00"
               defaultValue={priceEDLP}
-              borderColor={!priceEDLPPositive && showErrors ? "red" : "gray.200"}
+              borderColor={
+                !priceEDLPPositive && showErrors ? "red" : "gray.200"
+              }
               borderWidth={!priceEDLPPositive && showErrors ? "2px" : "1px"}
               onChange={handlePriceEDLP}
             />

--- a/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
+++ b/frontend/src/components/pages/CampCreation/CampDetails/index.tsx
@@ -161,6 +161,7 @@ const CampCreationDetails = ({
   };
 
   const campFeePositive = dailyCampFee > 0;
+  const priceEDLPPositive = priceEDLP > 0;
   const ageLowerPositive = ageLower > 0;
   const ageUpperPositive = ageUpper > 0;
   const ageLowerLessThanAgeUpper = ageLower <= ageUpper;
@@ -432,12 +433,12 @@ const CampCreationDetails = ({
               type="number"
               placeholder="0.00"
               defaultValue={priceEDLP}
-              borderColor={!priceEDLP && showErrors ? "red" : "gray.200"}
-              borderWidth={!priceEDLP && showErrors ? "2px" : "1px"}
+              borderColor={!priceEDLPPositive && showErrors ? "red" : "gray.200"}
+              borderWidth={!priceEDLPPositive && showErrors ? "2px" : "1px"}
               onChange={handlePriceEDLP}
             />
           </InputGroup>
-          {errorText(priceEDLP, "You must add a fee.")}
+          {errorText(priceEDLPPositive, "You must add a non-negative fee.")}
         </Box>
       )}
       <Box

--- a/frontend/src/components/pages/CampCreation/index.tsx
+++ b/frontend/src/components/pages/CampCreation/index.tsx
@@ -127,7 +127,7 @@ const CampCreationPage = (): React.ReactElement => {
     (offersEDLP
       ? earliestDropOffTime &&
         latestPickUpTime &&
-        priceEDLP &&
+        priceEDLP > 0 &&
         earlyDropoffTimeBeforeLatePickupTime &&
         earlyDropoffTimeBeforeStartTime &&
         endTimeBeforeLatePickupTime


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add validation to prevent negative amounts for EDLP during camp creation](https://www.notion.so/uwblueprintexecs/Add-validation-to-prevent-negative-amounts-for-EDLP-during-camp-creation-04780e5457824f33837c44ec2599f8f6?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add validation that EDLP amount is non-negative during camp creation


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to http://localhost:3000/admin/add-camp
2. Fill out necessary information
3. Checkbox "Camp offers early drop-off and late pick-up"
4. Try:
* enter 0 and click Next -> verify error message "You must add a non-negative fee" pops up and Next button is disabled
<img width="1045" alt="Screen Shot 2023-07-31 at 9 38 09 PM" src="https://github.com/uwblueprint/focus-on-nature/assets/88808428/fed8f0b0-4237-4acd-8a32-238561fbc8bb">
* enter -10 and click Next -> verify error message "You must add a non-negative fee" pops up and Next button is disabled
<img width="1052" alt="Screen Shot 2023-07-31 at 9 38 24 PM" src="https://github.com/uwblueprint/focus-on-nature/assets/88808428/51f2bbbd-56f8-421e-8384-98dd47aae5fd">
* enter 10 and click Next -> verify can successfully click Next to go to next step
<img width="1042" alt="Screen Shot 2023-07-31 at 9 38 17 PM" src="https://github.com/uwblueprint/focus-on-nature/assets/88808428/81d38f09-0caa-4c90-a670-c04b26eb7362">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Error is displayed when EDLP amount is 0 or negative
* Can't proceed to next page when EDLP amount is 0 or negative
* Same behaviour as other fields related to price (e.g. Daily Camp Fee)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
