### PR TITLE
Catherine derrick/error banner and coupon display

### DIFF
--- a/backend/typescript/rest/camperRoutes.ts
+++ b/backend/typescript/rest/camperRoutes.ts
@@ -89,6 +89,7 @@ camperRouter.get(
   },
 );
 
+// ROLES: Unprotected
 camperRouter.get("/refund/:refundCode", async (req, res) => {
   const { refundCode } = req.params;
   try {
@@ -96,6 +97,20 @@ camperRouter.get("/refund/:refundCode", async (req, res) => {
       (refundCode as unknown) as string,
     );
     res.status(200).json(refundInfo);
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
+});
+
+// ROLES: Unprotected
+// Used to contact stripe to obtain refund discount information
+camperRouter.get("/refund-discount-info/:chargeId", async (req, res) => {
+  const { chargeId } = req.params;
+  try {
+    const discountInfo = await camperService.getRefundDiscountInfo(
+      (chargeId as unknown) as string,
+    );
+    res.status(200).json(discountInfo);
   } catch (error: unknown) {
     res.status(500).json({ error: getErrorMessage(error) });
   }

--- a/backend/typescript/services/interfaces/camperService.ts
+++ b/backend/typescript/services/interfaces/camperService.ts
@@ -140,6 +140,13 @@ interface ICamperService {
    * @throws Error if retrieval fails
    */
   getRefundInfo(refundCode: string): Promise<RefundDTO>;
+
+  /**
+   * Returns the associated discount from coupons from a specific chargeId
+   * @param chargeId code specific to the checkout session
+   * @throws Error if retrieval fails
+   */
+  getRefundDiscountInfo(chargeId: string): Promise<number>;
 }
 
 export default ICamperService;

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -156,9 +156,12 @@ const getRefundInfo = async (refundCode: string): Promise<RefundDTO[]> => {
 
 const getRefundDiscountInfo = async (chargeId: string): Promise<number> => {
   try {
-    const { data } = await baseAPIClient.get(`/campers/refund-discount-info/${chargeId}`, {
-      headers: { Authorization: getBearerToken() },
-    });
+    const { data } = await baseAPIClient.get(
+      `/campers/refund-discount-info/${chargeId}`,
+      {
+        headers: { Authorization: getBearerToken() },
+      },
+    );
     return data;
   } catch (error) {
     return error as number;

--- a/frontend/src/APIClients/CamperAPIClient.ts
+++ b/frontend/src/APIClients/CamperAPIClient.ts
@@ -154,6 +154,17 @@ const getRefundInfo = async (refundCode: string): Promise<RefundDTO[]> => {
   }
 };
 
+const getRefundDiscountInfo = async (chargeId: string): Promise<number> => {
+  try {
+    const { data } = await baseAPIClient.get(`/campers/refund-discount-info/${chargeId}`, {
+      headers: { Authorization: getBearerToken() },
+    });
+    return data;
+  } catch (error) {
+    return error as number;
+  }
+};
+
 const confirmPayment = async (chargeId: string): Promise<boolean> => {
   try {
     const { data } = await baseAPIClient.post(
@@ -180,4 +191,5 @@ export default {
   waitlistCampers,
   confirmPayment,
   getRefundInfo,
+  getRefundDiscountInfo,
 };

--- a/frontend/src/components/pages/CamperRefundCancellation/CamperRefundFooter.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/CamperRefundFooter.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { Flex, Button } from "@chakra-ui/react";
 
-const CamperRefundFooter = (): React.ReactElement => {
+type CamperRefundFooterProps = {
+  isDisabled: boolean;
+};
+
+const CamperRefundFooter = ({
+  isDisabled,
+}: CamperRefundFooterProps): React.ReactElement => {
   return (
     <Flex
       color="#FFFFFF"
@@ -24,6 +30,7 @@ const CamperRefundFooter = (): React.ReactElement => {
         variant="primary"
         background="primary.green.100"
         textStyle="buttonSemiBold"
+        disabled={isDisabled}
         py="12px"
         px="25px"
       >

--- a/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
@@ -117,8 +117,6 @@ const CamperRefundInfoCard = ({
     const updatedRefundAmountMap = [...refundAmountMap];
     updatedRefundAmountMap[index] = checked ? getTotalRefundForCamper() : 0;
     setRefundAmountMap(updatedRefundAmountMap);
-    console.log(updatedCheckedRefunds);
-    console.log(updatedRefundAmountMap);
   };
 
   const valid = isRefundValid();

--- a/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
@@ -16,6 +16,8 @@ type CamperRefundInfoCardProps = {
   camperNum: number;
   instances: Array<CamperRefundDTO>;
   setCardsDisabled: React.Dispatch<React.SetStateAction<boolean>>;
+  checkedRefunds: Array<boolean>;
+  setCheckedRefunds: React.Dispatch<React.SetStateAction<boolean[]>>;
   refundAmountMap: Array<number>;
   setRefundAmountMap: React.Dispatch<React.SetStateAction<Array<number>>>;
 };
@@ -27,6 +29,8 @@ const CamperRefundInfoCard = ({
   camperNum,
   instances,
   setCardsDisabled,
+  checkedRefunds,
+  setCheckedRefunds,
   refundAmountMap,
   setRefundAmountMap,
 }: CamperRefundInfoCardProps): React.ReactElement => {
@@ -105,11 +109,16 @@ const CamperRefundInfoCard = ({
   };
 
   const handleCheckboxChange = (index: number) => {
-    // const updatedCheckedRefunds = [...checkedRefunds];
-    // const checked = !updatedCheckedRefunds[index];
-    // updatedCheckedRefunds[index] = checked;
-    // setCheckedRefunds(updatedCheckedRefunds);
-    // console.log(updatedCheckedRefunds);
+    const updatedCheckedRefunds = [...checkedRefunds];
+    const checked = !updatedCheckedRefunds[index];
+    updatedCheckedRefunds[index] = checked;
+    setCheckedRefunds(updatedCheckedRefunds);
+
+    const updatedRefundAmountMap = [...refundAmountMap];
+    updatedRefundAmountMap[index] = checked ? getTotalRefundForCamper() : 0;
+    setRefundAmountMap(updatedRefundAmountMap);
+    console.log(updatedCheckedRefunds);
+    console.log(updatedRefundAmountMap);
   };
 
   const valid = isRefundValid();

--- a/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/CamperRefundInfoCard.tsx
@@ -15,6 +15,9 @@ type CamperRefundInfoCardProps = {
   lastName: string;
   camperNum: number;
   instances: Array<CamperRefundDTO>;
+  setCardsDisabled: React.Dispatch<React.SetStateAction<boolean>>;
+  refundAmountMap: Array<number>;
+  setRefundAmountMap: React.Dispatch<React.SetStateAction<Array<number>>>;
 };
 
 const CamperRefundInfoCard = ({
@@ -23,6 +26,9 @@ const CamperRefundInfoCard = ({
   lastName,
   camperNum,
   instances,
+  setCardsDisabled,
+  refundAmountMap,
+  setRefundAmountMap,
 }: CamperRefundInfoCardProps): React.ReactElement => {
   const getTimeDifference = (date1: Date, date2: Date): number => {
     const date1Time = date1.getHours() * 60 + date1.getMinutes();
@@ -98,7 +104,18 @@ const CamperRefundInfoCard = ({
     return firstDate - today >= thirtyDays;
   };
 
+  const handleCheckboxChange = (index: number) => {
+    // const updatedCheckedRefunds = [...checkedRefunds];
+    // const checked = !updatedCheckedRefunds[index];
+    // updatedCheckedRefunds[index] = checked;
+    // setCheckedRefunds(updatedCheckedRefunds);
+    // console.log(updatedCheckedRefunds);
+  };
+
   const valid = isRefundValid();
+  if (!valid) {
+    setCardsDisabled(true);
+  }
 
   const textColor = valid ? "#000000" : "#00000066";
 
@@ -122,6 +139,7 @@ const CamperRefundInfoCard = ({
         <Checkbox
           isDisabled={!valid}
           defaultChecked={valid}
+          onChange={() => handleCheckboxChange(camperNum - 1)}
           colorScheme="green"
           size="lg"
         >

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -9,6 +9,7 @@ import {
   useToast,
   Spinner,
   Center,
+  Divider,
 } from "@chakra-ui/react";
 
 import FONIcon from "../../../assets/fon_icon.svg";
@@ -29,6 +30,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
   const [campName, setCampName] = useState<string>("");
   const [validCode, setValidCode] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
+  const [refundDiscountAmount, setRefundDiscountAmount] = useState<number>(-1);
 
   // The camper-refund-cancellation route will have an id to identify the refund code
   const { id: refundCode } = useParams<{ id: string }>();
@@ -36,10 +38,14 @@ const CamperRefundCancellation = (): React.ReactElement => {
   useEffect(() => {
     const getRefundInfoById = async (code: string) => {
       try {
-        const getResponse = await CamperAPIClient.getRefundInfo(code);
+        const getRefunds = await CamperAPIClient.getRefundInfo(code);
         setValidCode(true);
-        setRefunds(getResponse);
-        setCampName(getResponse[0].campName);
+        setRefunds(getRefunds);
+        setCampName(getRefunds[0].campName);
+        const getDiscountAmount = await CamperAPIClient.getRefundDiscountInfo(
+          getRefunds[0].instances[0].chargeId,
+        );
+        setRefundDiscountAmount(getDiscountAmount);
       } catch {
         toast({
           description: `Unable to retrieve Refund Info.`,
@@ -147,26 +153,60 @@ const CamperRefundCancellation = (): React.ReactElement => {
               );
             })}
           </Box>
-          <Flex width="100%" justifyContent="space-between">
-            <Text
-              textStyle={{
-                sm: "xSmallBold",
-                md: "captionSemiBold",
-                lg: "displayMediumBold",
-              }}
-            >
-              Total Refund
-            </Text>
-            <Text
-              textStyle={{
-                sm: "xSmallBold",
-                md: "captionSemiBold",
-                lg: "displayMediumBold",
-              }}
-            >
-              ${getTotalRefund()}
-            </Text>
-          </Flex>
+          {refundDiscountAmount > 0 && (
+            <>
+              <Box>
+                <Flex width="100%" justifyContent="space-between">
+                  <Text textStyle="displayMediumBold">Refund Amount</Text>
+                  <Text textStyle="displayMediumBold">${getTotalRefund()}</Text>
+                </Flex>
+                <Flex width="100%" justifyContent="space-between" py="10px">
+                  <Text textStyle="captionSemiBold">Discount</Text>
+                  <Text textStyle="captionSemiBold">
+                    -${refundDiscountAmount}
+                  </Text>
+                </Flex>
+              </Box>
+              <Divider borderColor="gray.500" height="4px" />
+            </>
+          )}
+
+          {refundDiscountAmount === 0 ? (
+            <Flex width="100%" justifyContent="space-between">
+              <Text
+                textStyle={{
+                  sm: "xSmallBold",
+                  md: "captionSemiBold",
+                  lg: "displayMediumBold",
+                }}
+              >
+                Total Refund
+              </Text>
+              <Text
+                textStyle={{
+                  sm: "xSmallBold",
+                  md: "captionSemiBold",
+                  lg: "displayMediumBold",
+                }}
+                py="10px"
+              >
+                ${getTotalRefund() - refundDiscountAmount}
+              </Text>
+            </Flex>
+          ) : (
+            <Flex width="100%" justifyContent="right">
+              <Text
+                textStyle={{
+                  sm: "xSmallBold",
+                  md: "captionSemiBold",
+                  lg: "displayMediumBold",
+                }}
+                py="10px"
+              >
+                ${getTotalRefund() - refundDiscountAmount}
+              </Text>
+            </Flex>
+          )}
         </Box>
       </Box>
       <CamperRefundFooter />

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -227,7 +227,9 @@ const CamperRefundCancellation = (): React.ReactElement => {
             </>
           )}
 
-          {proportionalDiscountAmount === 0 || cardsDisabled || !isCardChecked() ? (
+          {proportionalDiscountAmount === 0 ||
+          cardsDisabled ||
+          !isCardChecked() ? (
             <Flex width="100%" justifyContent="space-between">
               <Text
                 textStyle={{

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -98,7 +98,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
       state = state || isChecked;
     });
     return cardsDisabled || !state;
-  }
+  };
 
   if (loading) {
     return (

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -91,13 +91,17 @@ const CamperRefundCancellation = (): React.ReactElement => {
     return totalRefund;
   };
 
-  const isFooterButtonDisabled = (): boolean => {
-    // return true if disabled, false otherwise
+  const isCardChecked = (): boolean => {
     let state = false;
     checkedRefunds.forEach((isChecked) => {
       state = state || isChecked;
     });
-    return cardsDisabled || !state;
+    return state;
+  };
+
+  const isFooterButtonDisabled = (): boolean => {
+    // return true if disabled, false otherwise
+    return cardsDisabled || !isCardChecked();
   };
 
   if (loading) {
@@ -199,7 +203,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
               );
             })}
           </Box>
-          {refundDiscountAmount > 0 && (
+          {refundDiscountAmount > 0 && !cardsDisabled && isCardChecked() && (
             <>
               <Box>
                 <Flex width="100%" justifyContent="space-between">
@@ -217,7 +221,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
             </>
           )}
 
-          {refundDiscountAmount === 0 ? (
+          {refundDiscountAmount === 0 || cardsDisabled || !isCardChecked() ? (
             <Flex width="100%" justifyContent="space-between">
               <Text
                 textStyle={{
@@ -236,7 +240,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
                 }}
                 py="10px"
               >
-                ${getTotalRefund() - refundDiscountAmount}
+                ${Math.max(getTotalRefund(), 0)}
               </Text>
             </Flex>
           ) : (

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -31,6 +31,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
   const [validCode, setValidCode] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [refundDiscountAmount, setRefundDiscountAmount] = useState<number>(-1);
+  const [totalRefundAmount, setTotalRefundAmount] = useState<number>(-1);
   const [cardsDisabled, setCardsDisabled] = useState<boolean>(false);
   const [refundAmountMap, setRefundAmountMap] = useState<Array<number>>([]);
   const [checkedRefunds, setCheckedRefunds] = useState<Array<boolean>>([]);
@@ -39,6 +40,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
   useEffect(() => {
     const getRefundInfoById = async (code: string) => {
       let numberOfRefunds = 0;
+      let allRefunds = 0;
       try {
         const getRefunds = await CamperAPIClient.getRefundInfo(code);
         numberOfRefunds = getRefunds.length;
@@ -57,7 +59,9 @@ const CamperRefundCancellation = (): React.ReactElement => {
               instance.charges.earlyDropoff +
               instance.charges.latePickup +
               instance.charges.camp;
+            allRefunds += charge;
           });
+          setTotalRefundAmount(allRefunds);
           refundAmountMapArray[index] = charge;
         });
         setRefundAmountMap(refundAmountMapArray);
@@ -90,6 +94,8 @@ const CamperRefundCancellation = (): React.ReactElement => {
     });
     return totalRefund;
   };
+  const discountPercentage = refundDiscountAmount / totalRefundAmount;
+  const proportionalDiscountAmount = discountPercentage * getTotalRefund();
 
   const isCardChecked = (): boolean => {
     let state = false;
@@ -203,7 +209,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
               );
             })}
           </Box>
-          {refundDiscountAmount > 0 && !cardsDisabled && isCardChecked() && (
+          {proportionalDiscountAmount > 0 && !cardsDisabled && isCardChecked() && (
             <>
               <Box>
                 <Flex width="100%" justifyContent="space-between">
@@ -213,7 +219,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
                 <Flex width="100%" justifyContent="space-between" py="10px">
                   <Text textStyle="captionSemiBold">Discount</Text>
                   <Text textStyle="captionSemiBold">
-                    -${refundDiscountAmount}
+                    -${proportionalDiscountAmount}
                   </Text>
                 </Flex>
               </Box>
@@ -221,7 +227,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
             </>
           )}
 
-          {refundDiscountAmount === 0 || cardsDisabled || !isCardChecked() ? (
+          {proportionalDiscountAmount === 0 || cardsDisabled || !isCardChecked() ? (
             <Flex width="100%" justifyContent="space-between">
               <Text
                 textStyle={{
@@ -253,7 +259,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
                 }}
                 py="10px"
               >
-                ${getTotalRefund() - refundDiscountAmount}
+                ${getTotalRefund() - proportionalDiscountAmount}
               </Text>
             </Flex>
           )}

--- a/frontend/src/components/pages/CamperRefundCancellation/index.tsx
+++ b/frontend/src/components/pages/CamperRefundCancellation/index.tsx
@@ -36,21 +36,6 @@ const CamperRefundCancellation = (): React.ReactElement => {
   const [checkedRefunds, setCheckedRefunds] = useState<Array<boolean>>([]);
   const { id: refundCode } = useParams<{ id: string }>();
 
-  const intializeRefundAmountMap = () => {
-    const refundAmounts = [...refundAmountMap]
-    refunds.forEach((refund, index) => {
-      let charge = 0;
-      refund.instances.forEach((instance) => {
-        charge +=
-          instance.charges.earlyDropoff +
-          instance.charges.latePickup +
-          instance.charges.camp;
-      });
-      refundAmounts[index] = charge;
-      setRefundAmountMap(refundAmounts);
-    });
-  };
-
   useEffect(() => {
     const getRefundInfoById = async (code: string) => {
       let numberOfRefunds = 0;
@@ -105,6 +90,15 @@ const CamperRefundCancellation = (): React.ReactElement => {
     });
     return totalRefund;
   };
+
+  const isFooterButtonDisabled = (): boolean => {
+    // return true if disabled, false otherwise
+    let state = false;
+    checkedRefunds.forEach((isChecked) => {
+      state = state || isChecked;
+    });
+    return cardsDisabled || !state;
+  }
 
   if (loading) {
     return (
@@ -261,7 +255,7 @@ const CamperRefundCancellation = (): React.ReactElement => {
           )}
         </Box>
       </Box>
-      <CamperRefundFooter />
+      <CamperRefundFooter isDisabled={isFooterButtonDisabled()} />
     </>
   );
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Cancellation-Refund-Populate-camper-selection-page-with-real-data-edge-cases](https://www.notion.so/uwblueprintexecs/Cancellation-Refund-Populate-camper-selection-page-with-real-data-edge-cases-a593a616bdba48fb88206b909a79dbdb)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented a `GET` endpoint that retrieves discount information from stripe
* Leveraged the endpoint to display discount information (if any). Here is a screenshot of what it looks like:<img width="942" alt="image" src="https://github.com/uwblueprint/focus-on-nature/assets/57463206/eb3a1169-3f73-470e-9fd9-f2be1648564f"> _**Note**: When the initial Spinner/loading screen will continue until the information from stripe is successfully retrieved, aka error handled gracefully._
* Added logic to display a banner when sessions are disabled and have the **Total Refund = 0**. Here is a screenshot: <img width="639" alt="image" src="https://github.com/uwblueprint/focus-on-nature/assets/57463206/3055a0f0-5247-43ff-b17f-8501e1b4c2ca">
* Disabled the `Request Refund` button if either: None of the cards are selected, or refund is disabled
* PR feedback: Discount is distributed proportionally to cards selected. Here is a screenshot:
![fix-distribute discount to be proportional to selected refund cards](https://github.com/uwblueprint/focus-on-nature/assets/25796421/13574e9b-6934-494a-b91c-cdb0cc6408ae)


I also added a unrelated change that is a nice-to-have:
* The **Total Refund** value now changes based on what card is checked. Discount also works with this.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Not sure how to test the discount, are there any chargeId's with applied coupons? In that case, we can hard-code it and view it in the UI. The screenshot above is when it's hardcoded to show even if the discount is `0`
2. Go to this link: http://localhost:3000/refund/0013cb7b1f3a5325. Check to see if the Request Refund Button is disabled when nothing is selected and also make sure the error banner does not appear. Also select/de-select to see if the `Total Refund` is updated correctly each time
3. Go to this link: http://localhost:3000/refund/73cf6242a9dfbdd2. Make sure the Request Refund Button is disabled and the banner shows
4. Go to this link: http://localhost:3000/refund/5e74cb1c47b51ab0. Make sure discount ( TEST15 = 15%) changes proportionally to cards that are selected. Ensure the refund amount - discount is correct calculation. Do this check for session cards that have different prices.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Does the UI look fine?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
